### PR TITLE
feat(web): add maintenance and save-data search flows

### DIFF
--- a/app/game-library/maintenance/page.tsx
+++ b/app/game-library/maintenance/page.tsx
@@ -1,0 +1,5 @@
+import MaintenanceDashboardPage from '@/components/organisms/GameManagement/MaintenanceDashboardPage';
+
+export default function GameLibraryMaintenancePage() {
+  return <MaintenanceDashboardPage />;
+}

--- a/app/game-library/page.tsx
+++ b/app/game-library/page.tsx
@@ -9,6 +9,22 @@ export default function GameLibraryPage() {
       sectionLabel="Game Library"
       sectionTitle="ゲームライブラリ"
       sectionDescription="所有しているゲーム機、ゲームソフト、アカウント、メモリーカード、セーブデータを管理します。"
+      extraCards={[
+        {
+          href: '/game-library/maintenance',
+          shortLabel: 'Maintenance',
+          title: '保守履歴',
+          description: 'ゲーム機・ゲームソフト・メモリーカードの保守状態を横断表示し、順次記録できます。',
+          actionLabel: '保守履歴を開く',
+        },
+        {
+          href: '/game-library/save-data-search',
+          shortLabel: 'Search',
+          title: '横断セーブデータ検索',
+          description: '共通 variant と複数の schema 条件グループを使い、作品横断でセーブデータを検索できます。',
+          actionLabel: '検索画面を開く',
+        },
+      ]}
     />
   );
 }

--- a/app/game-library/save-data-search/page.tsx
+++ b/app/game-library/save-data-search/page.tsx
@@ -1,0 +1,5 @@
+import SaveDataSearchPage from '@/components/organisms/GameManagement/SaveDataSearchPage';
+
+export default function GameLibrarySaveDataSearchPage() {
+  return <SaveDataSearchPage />;
+}

--- a/app/game-management/page.tsx
+++ b/app/game-management/page.tsx
@@ -9,6 +9,7 @@ export default function GameManagementPage() {
     <GameManagementDashboard
       basePath="/game-management"
       resourceKeys={ADMIN_RESOURCE_ORDER}
+      requiresAdmin
       sectionLabel={texts.sectionLabel}
       sectionTitle={texts.sectionTitle}
       sectionDescription={texts.sectionDescription}

--- a/components/organisms/GameManagement/EditorDialog.tsx
+++ b/components/organisms/GameManagement/EditorDialog.tsx
@@ -25,9 +25,11 @@ import {
   formatSaveDataFieldValueForList,
   mergeSchemaWithSaveData,
 } from '@/lib/game-management/save-data-fields';
+import { buildMaintenanceSummaryText, supportsMaintenance } from '@/lib/game-management/maintenance';
 import { trialGetResourceById } from '@/lib/game-management/trial';
 import type {
   ManagementLookups,
+  MaintenanceSummaryDto,
   ResourceKey,
   SaveDataDto,
   SaveDataSchemaDto,
@@ -35,6 +37,7 @@ import type {
 } from '@/lib/game-management/types';
 import { numberOrNull, getStoryProgressLabel } from './helpers';
 import { createContinueFormState, createSeededFormState, buildInitialFormState } from './form-state';
+import MaintenanceRecordsSection from './MaintenanceRecordsSection';
 import { validateForm } from './validation';
 import { selectOptionsFromLookups, optionize } from './options';
 import { FormFields } from './form-fields';
@@ -93,6 +96,7 @@ export default function EditorDialog({
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [maintenanceDialogOpen, setMaintenanceDialogOpen] = useState(false);
 
   const [saveDataSchema, setSaveDataSchema] = useState<SaveDataSchemaDto | null>(null);
   const [saveDataSchemaLoading, setSaveDataSchemaLoading] = useState(false);
@@ -105,45 +109,47 @@ export default function EditorDialog({
   // Record loading
   // ---------------------------------------------------------------------------
 
-  useEffect(() => {
-    if (!open) return;
-    let cancelled = false;
+  const reloadCurrentRecord = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setSuccess(null);
 
-    const doLoad = async () => {
-      setLoading(true);
-      setError(null);
-      setSuccess(null);
-
-      try {
-        if (recordId === null) {
-          setRecord(null);
-          setFormState(createSeededFormState(initialFormState));
-        } else {
-          let nextRecord: unknown;
-          if (isTrial) {
-            nextRecord = trialGetResourceById(resourceKey, recordId);
-            if (!nextRecord) throw new Error(`レコード #${recordId} が見つかりません。`);
-          } else {
-            nextRecord = await fetchResourceById(resourceKey, String(recordId));
-          }
-          if (cancelled) return;
-          setRecord(nextRecord);
-          setFormState(buildInitialFormState(resourceKey, nextRecord));
-        }
-      } catch (err) {
-        if (cancelled) return;
-        setError(getGameManagementErrorMessage(err, {
-          fallback: resources.gameManagement.errors.detailLoad,
-          adminFallback: resources.gameManagement.errors.adminRequired,
-        }));
-      } finally {
-        if (!cancelled) setLoading(false);
+    try {
+      if (recordId === null) {
+        setRecord(null);
+        setFormState(createSeededFormState(initialFormState));
+        return;
       }
-    };
 
-    void doLoad();
-    return () => { cancelled = true; };
-  }, [initialFormState, open, recordId, isTrial, resourceKey]);
+      let nextRecord: unknown;
+      if (isTrial) {
+        nextRecord = trialGetResourceById(resourceKey, recordId);
+        if (!nextRecord) {
+          throw new Error(`レコード #${recordId} が見つかりません。`);
+        }
+      } else {
+        nextRecord = await fetchResourceById(resourceKey, String(recordId));
+      }
+
+      setRecord(nextRecord);
+      setFormState(buildInitialFormState(resourceKey, nextRecord));
+    } catch (err) {
+      setError(getGameManagementErrorMessage(err, {
+        fallback: resources.gameManagement.errors.detailLoad,
+        adminFallback: resources.gameManagement.errors.adminRequired,
+      }));
+    } finally {
+      setLoading(false);
+    }
+  }, [initialFormState, isTrial, recordId, resourceKey]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    void reloadCurrentRecord();
+  }, [open, reloadCurrentRecord]);
 
   // Reset on close
   useEffect(() => {
@@ -159,6 +165,7 @@ export default function EditorDialog({
     setError(null);
     setSuccess(null);
     setDeleteDialogOpen(false);
+    setMaintenanceDialogOpen(false);
   }, [initialFormState, open]);
 
   // ---------------------------------------------------------------------------
@@ -247,6 +254,19 @@ export default function EditorDialog({
       : {};
     return getStoryProgressLabel(gsmId, spdId, fallbackMap) ?? null;
   }, [formState.gameSoftwareMasterId, formState.storyProgressDefinitionId, resourceKey, storyProgressSchema]);
+
+  const maintenanceSummary = useMemo<MaintenanceSummaryDto | undefined>(() => {
+    if (!record || !supportsMaintenance(resourceKey)) {
+      return undefined;
+    }
+
+    return (record as { maintenance?: MaintenanceSummaryDto }).maintenance;
+  }, [record, resourceKey]);
+
+  const handleMaintenanceChanged = useCallback(async () => {
+    await reloadCurrentRecord();
+    onDataChanged();
+  }, [onDataChanged, reloadCurrentRecord]);
 
   // ---------------------------------------------------------------------------
   // Save
@@ -491,6 +511,55 @@ export default function EditorDialog({
                   {record ? <ResourceSummary resourceKey={resourceKey} record={record} lookups={lookups} storyProgressLabel={selectedStoryProgressLabel} /> : null}
                 </div>
               )}
+               {!isNew && recordId != null && supportsMaintenance(resourceKey) ? (
+                 <>
+                   <section className="space-y-4 rounded-2xl border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900/60">
+                     <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                       <div className="space-y-2">
+                         <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-100">保守履歴</h3>
+                         <p className="text-sm leading-6 text-zinc-500 dark:text-zinc-300">
+                           {buildMaintenanceSummaryText(maintenanceSummary)}
+                         </p>
+                       </div>
+                       <CustomButton variant="neutral" onClick={() => setMaintenanceDialogOpen(true)}>
+                         履歴を見る
+                       </CustomButton>
+                     </div>
+                     {isTrial ? (
+                       <CustomMessageArea variant="info">
+                         トライアルモードでは保守履歴ダイアログは確認できますが、保存操作は利用できません。
+                       </CustomMessageArea>
+                     ) : null}
+                   </section>
+                   <Dialog
+                     open={maintenanceDialogOpen}
+                     onClose={() => setMaintenanceDialogOpen(false)}
+                     title={`${definition.shortLabel}の保守履歴`}
+                     size="lg"
+                     footer={(
+                       <DialogFooterLayout
+                         layoutMode={layoutMode}
+                         trailing={(
+                           <CustomButton variant="neutral" onClick={() => setMaintenanceDialogOpen(false)}>
+                             閉じる
+                           </CustomButton>
+                         )}
+                       />
+                     )}
+                   >
+                     <MaintenanceRecordsSection
+                       key={`${resourceKey}:${recordId}:${isTrial ? 'trial' : 'live'}`}
+                       resourceKey={resourceKey}
+                       parentId={recordId}
+                       summary={maintenanceSummary}
+                       readOnly={isViewMode}
+                       trialMode={isTrial}
+                       layoutMode={layoutMode}
+                       onChanged={() => { void handleMaintenanceChanged(); }}
+                     />
+                   </Dialog>
+                 </>
+               ) : null}
               {resourceKey === 'save-datas' && record && !isNew ? (() => {
                 const saveData = record as SaveDataDto;
                 const mergedFields = mergeSchemaWithSaveData(saveDataSchema, saveData);

--- a/components/organisms/GameManagement/MaintenanceDashboardPage.tsx
+++ b/components/organisms/GameManagement/MaintenanceDashboardPage.tsx
@@ -1,0 +1,360 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import CustomButton from '@/components/atoms/CustomButton';
+import CustomComboBox from '@/components/atoms/CustomComboBox';
+import CustomLabel from '@/components/atoms/CustomLabel';
+import CustomMessageArea from '@/components/atoms/CustomMessageArea';
+import DataTable, { DATA_TABLE_DEFAULT_PAGE_HEIGHT, type DataTableColumn } from '@/components/molecules/DataTable';
+import Dialog, { DialogFooterLayout } from '@/components/molecules/Dialog';
+import ResponsiveActionGroup from '@/components/molecules/ResponsiveActionGroup';
+import {
+  fetchAuthenticatedUserLookups,
+  fetchPublicMasterLookups,
+  getGameManagementErrorMessage,
+} from '@/lib/game-management/api';
+import {
+  buildMaintenanceSummaryText,
+  formatMaintenanceDate,
+  getMaintenanceHealthStatusLabel,
+  MAINTENANCE_FILTER_OPTIONS,
+} from '@/lib/game-management/maintenance';
+import { buildTrialUserData } from '@/lib/game-management/trial';
+import type {
+  MaintenanceHealthFilter,
+  MaintenanceSummaryDto,
+  ManagementLookups,
+} from '@/lib/game-management/types';
+import { useResponsiveLayoutMode } from '@/lib/hooks/useResponsiveLayoutMode';
+import resources from '@/lib/resources';
+import {
+  getGameConsoleDisplay,
+  getGameConsoleMasterName,
+  getGameSoftwareDisplay,
+  getGameSoftwareMasterName,
+  getMemoryCardDisplay,
+  getMemoryCardEditionMasterName,
+} from './helpers';
+import MaintenanceRecordsSection, { type MaintenanceResourceKey } from './MaintenanceRecordsSection';
+import { PageCard, PageFrame, TrialBanner } from './shared';
+
+type MaintenanceTargetRow = {
+  tableRowKey: string;
+  id: number;
+  resourceKey: MaintenanceResourceKey;
+  resourceLabel: string;
+  name: string;
+  detail: string;
+  summary: string;
+  health: string;
+  nextDate: string;
+  edit: string;
+  maintenanceSummary: MaintenanceSummaryDto;
+};
+
+type MaintenanceDialogState = {
+  targets: MaintenanceTargetRow[];
+  index: number;
+  autoAdvance: boolean;
+};
+
+function matchesMaintenanceFilter(summary: MaintenanceSummaryDto, filter: MaintenanceHealthFilter): boolean {
+  switch (filter) {
+    case 'ExcludeUnhealthy':
+      return summary.latestHealthStatus !== 2;
+    case 'OnlyUnhealthy':
+      return summary.latestHealthStatus === 2;
+    default:
+      return true;
+  }
+}
+
+function buildMaintenanceTargets(lookups: ManagementLookups, filter: MaintenanceHealthFilter): MaintenanceTargetRow[] {
+  const rows: MaintenanceTargetRow[] = [
+    ...lookups.gameConsoles
+      .filter((item) => matchesMaintenanceFilter(item.maintenance, filter))
+      .map((item) => ({
+        tableRowKey: `game-consoles:${item.id}`,
+        id: item.id,
+        resourceKey: 'game-consoles' as const,
+        resourceLabel: 'ゲーム機',
+        name: getGameConsoleDisplay(item, lookups),
+        detail: getGameConsoleMasterName(item.gameConsoleMasterId, lookups),
+        summary: buildMaintenanceSummaryText(item.maintenance),
+        health: getMaintenanceHealthStatusLabel(item.maintenance.latestHealthStatus),
+        nextDate: formatMaintenanceDate(item.maintenance.nextMaintenanceDate),
+        edit: '履歴を見る',
+        maintenanceSummary: item.maintenance,
+      })),
+    ...lookups.gameSoftwares
+      .filter((item) => matchesMaintenanceFilter(item.maintenance, filter))
+      .map((item) => ({
+        tableRowKey: `game-softwares:${item.id}`,
+        id: item.id,
+        resourceKey: 'game-softwares' as const,
+        resourceLabel: 'ゲームソフト',
+        name: getGameSoftwareDisplay(item, lookups),
+        detail: [
+          getGameSoftwareMasterName(item.gameSoftwareMasterId, lookups),
+          item.variant == null ? null : item.variant === 0 ? 'パッケージ版' : 'ダウンロード版',
+        ].filter(Boolean).join(' / '),
+        summary: buildMaintenanceSummaryText(item.maintenance),
+        health: getMaintenanceHealthStatusLabel(item.maintenance.latestHealthStatus),
+        nextDate: formatMaintenanceDate(item.maintenance.nextMaintenanceDate),
+        edit: '履歴を見る',
+        maintenanceSummary: item.maintenance,
+      })),
+    ...lookups.memoryCards
+      .filter((item) => matchesMaintenanceFilter(item.maintenance, filter))
+      .map((item) => ({
+        tableRowKey: `memory-cards:${item.id}`,
+        id: item.id,
+        resourceKey: 'memory-cards' as const,
+        resourceLabel: 'メモリーカード',
+        name: getMemoryCardDisplay(item, lookups),
+        detail: getMemoryCardEditionMasterName(item.memoryCardEditionMasterId, lookups),
+        summary: buildMaintenanceSummaryText(item.maintenance),
+        health: getMaintenanceHealthStatusLabel(item.maintenance.latestHealthStatus),
+        nextDate: formatMaintenanceDate(item.maintenance.nextMaintenanceDate),
+        edit: '履歴を見る',
+        maintenanceSummary: item.maintenance,
+      })),
+  ];
+
+  return rows.sort((left, right) => {
+    const overdueDelta = Number(right.maintenanceSummary.isOverdue) - Number(left.maintenanceSummary.isOverdue);
+    if (overdueDelta !== 0) {
+      return overdueDelta;
+    }
+
+    const healthDelta = right.maintenanceSummary.latestHealthStatus - left.maintenanceSummary.latestHealthStatus;
+    if (healthDelta !== 0) {
+      return healthDelta;
+    }
+
+    const leftDate = left.maintenanceSummary.nextMaintenanceDate ?? '9999-12-31';
+    const rightDate = right.maintenanceSummary.nextMaintenanceDate ?? '9999-12-31';
+    return leftDate.localeCompare(rightDate, 'ja') || left.id - right.id;
+  });
+}
+
+export default function MaintenanceDashboardPage() {
+  const { data: session } = useSession();
+  const isTrial = !session?.user;
+  const layoutMode = useResponsiveLayoutMode();
+  const [lookups, setLookups] = useState<ManagementLookups | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [queueMessage, setQueueMessage] = useState<string | null>(null);
+  const [maintenanceHealthFilter, setMaintenanceHealthFilter] = useState<MaintenanceHealthFilter>('All');
+  const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+  const [dialogState, setDialogState] = useState<MaintenanceDialogState | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const result = isTrial
+        ? { ...await fetchPublicMasterLookups(), ...buildTrialUserData() }
+        : await fetchAuthenticatedUserLookups({ maintenanceHealthFilter });
+      setLookups(result);
+    } catch (loadError) {
+      setError(getGameManagementErrorMessage(loadError, {
+        fallback: resources.gameManagement.errors.listLoad,
+      }));
+    } finally {
+      setLoading(false);
+    }
+  }, [isTrial, maintenanceHealthFilter]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const rows = useMemo(
+    () => (lookups ? buildMaintenanceTargets(lookups, maintenanceHealthFilter) : []),
+    [lookups, maintenanceHealthFilter],
+  );
+
+  const rowMap = useMemo(
+    () => new Map(rows.map((row) => [row.tableRowKey, row])),
+    [rows],
+  );
+
+  const queueTargets = useMemo(
+    () => rows.filter((row) => selectedKeys.includes(row.tableRowKey)),
+    [rows, selectedKeys],
+  );
+
+  const dialogTargets = useMemo(
+    () => dialogState?.targets.map((target) => rowMap.get(target.tableRowKey) ?? target) ?? [],
+    [dialogState, rowMap],
+  );
+
+  const activeTarget = dialogState ? dialogTargets[dialogState.index] ?? null : null;
+
+  const handleSaved = useCallback((mode: 'create' | 'update') => {
+    void load();
+
+    setDialogState((current) => {
+      if (!current || !current.autoAdvance || mode !== 'create') {
+        return current;
+      }
+
+      if (current.index >= current.targets.length - 1) {
+        setQueueMessage(`${current.targets.length} 件の保守記録キューを完了しました。`);
+        return null;
+      }
+
+      return {
+        ...current,
+        index: current.index + 1,
+      };
+    });
+  }, [load]);
+
+  const columns = useMemo<DataTableColumn<MaintenanceTargetRow>[]>(() => [
+    { key: 'resourceLabel', header: '種別', sortable: true, filterable: true, filterMode: 'select', width: '9rem' },
+    { key: 'name', header: '対象', sortable: true, filterable: true, width: '14rem' },
+    { key: 'detail', header: '詳細', filterable: true, width: '16rem' },
+    { key: 'health', header: '状態', sortable: true, filterable: true, filterMode: 'select', width: '8rem' },
+    { key: 'nextDate', header: '次回目安', sortable: true, filterable: true, filterMode: 'select', width: '8rem' },
+    { key: 'summary', header: '最新サマリー', filterable: true },
+    {
+      key: 'edit',
+      header: '操作',
+      width: '8rem',
+      render: (_value, row) => (
+        <button
+          type="button"
+          onClick={() => setDialogState({ targets: [row], index: 0, autoAdvance: false })}
+          className="text-sm font-semibold text-sky-700 underline-offset-2 hover:underline dark:text-sky-300"
+        >
+          履歴を見る
+        </button>
+      ),
+    },
+  ], []);
+
+  return (
+    <PageFrame
+      eyebrowLabel="Game Library"
+      title="保守履歴"
+      description="ゲーム機・ゲームソフト・メモリーカードの最新保守状態を横断表示し、選択した対象を順次記録できます。"
+      layoutMode={layoutMode}
+      actions={(
+        <>
+          <ResponsiveActionGroup layoutMode={layoutMode} mobileColumns={1}>
+            <Link href="/game-library" className="text-sm font-medium text-zinc-600 underline-offset-2 hover:underline dark:text-zinc-300">
+              ダッシュボードへ戻る
+            </Link>
+          </ResponsiveActionGroup>
+          <ResponsiveActionGroup layoutMode={layoutMode} mobileColumns={1} align="end">
+            <CustomButton
+              variant="accent"
+              disabled={queueTargets.length === 0}
+              onClick={() => setDialogState({ targets: queueTargets, index: 0, autoAdvance: true })}
+            >
+              選択した {queueTargets.length} 件を順次記録
+            </CustomButton>
+            <CustomButton onClick={() => void load()}>
+              再読み込み
+            </CustomButton>
+          </ResponsiveActionGroup>
+        </>
+      )}
+    >
+      {isTrial ? <TrialBanner /> : null}
+      {error ? <CustomMessageArea variant="error">{error}</CustomMessageArea> : null}
+      {queueMessage ? <CustomMessageArea variant="success">{queueMessage}</CustomMessageArea> : null}
+      <PageCard>
+        {loading ? (
+          <p className="text-sm text-zinc-500 dark:text-zinc-300">保守対象を読み込んでいます...</p>
+        ) : (
+          <div className="space-y-4">
+            <div className="grid gap-3 rounded-2xl border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900/60 md:grid-cols-[minmax(0,20rem)_1fr] md:items-end">
+              <div className="space-y-2">
+                <CustomLabel htmlFor="maintenance-dashboard-filter">保守状態</CustomLabel>
+                <CustomComboBox
+                  id="maintenance-dashboard-filter"
+                  value={maintenanceHealthFilter}
+                  onChange={(event) => setMaintenanceHealthFilter(event.target.value as MaintenanceHealthFilter)}
+                >
+                  {MAINTENANCE_FILTER_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>{option.label}</option>
+                  ))}
+                </CustomComboBox>
+              </div>
+              <p className="text-sm leading-6 text-zinc-500 dark:text-zinc-300">
+                一覧から対象を複数選択すると、保守記録ダイアログを順番に開いて記録できます。
+              </p>
+            </div>
+            <div className="flex flex-col gap-2 text-sm text-zinc-500 sm:flex-row sm:items-center sm:justify-between">
+              <span>表示件数: {rows.length} 件</span>
+              <span>選択中: {queueTargets.length} 件</span>
+            </div>
+            <DataTable
+              title="保守対象一覧"
+              columns={columns}
+              data={rows}
+              filterOptionsData={rows}
+              height={DATA_TABLE_DEFAULT_PAGE_HEIGHT}
+              rowKey="tableRowKey"
+              selectable
+              selectedKeys={selectedKeys}
+              onSelectionChange={setSelectedKeys}
+              paginated
+              resizable
+              emptyMessage="保守対象がありません。"
+            />
+          </div>
+        )}
+      </PageCard>
+      <Dialog
+        open={activeTarget != null}
+        onClose={() => setDialogState(null)}
+        title={activeTarget ? `${activeTarget.resourceLabel}の保守履歴` : '保守履歴'}
+        size="lg"
+        footer={(
+          <DialogFooterLayout
+            layoutMode={layoutMode}
+            status={dialogState?.autoAdvance && activeTarget ? (
+              <span role="status" aria-live="polite" className="text-xs text-zinc-500 dark:text-zinc-300">
+                {dialogState.index + 1} / {dialogTargets.length} 件目
+              </span>
+            ) : null}
+            trailing={(
+              <CustomButton variant="neutral" onClick={() => setDialogState(null)}>
+                閉じる
+              </CustomButton>
+            )}
+          />
+        )}
+      >
+        {activeTarget ? (
+          <div className="space-y-4">
+            <div className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4 text-sm text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900/60 dark:text-zinc-300">
+              <p className="font-semibold text-zinc-800 dark:text-zinc-100">{activeTarget.name}</p>
+              <p>{activeTarget.detail}</p>
+              <p className="mt-2">{activeTarget.summary}</p>
+            </div>
+            <MaintenanceRecordsSection
+              key={`${activeTarget.tableRowKey}:${dialogState?.index ?? 0}`}
+              resourceKey={activeTarget.resourceKey}
+              parentId={activeTarget.id}
+              summary={activeTarget.maintenanceSummary}
+              trialMode={isTrial}
+              autoOpenCreateOnMount={Boolean(dialogState?.autoAdvance) && !isTrial}
+              layoutMode={layoutMode}
+              onChanged={() => { void load(); }}
+              onSaved={handleSaved}
+            />
+          </div>
+        ) : null}
+      </Dialog>
+    </PageFrame>
+  );
+}

--- a/components/organisms/GameManagement/MaintenanceRecordsSection.tsx
+++ b/components/organisms/GameManagement/MaintenanceRecordsSection.tsx
@@ -1,0 +1,468 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import CustomButton from '@/components/atoms/CustomButton';
+import CustomCheckBox from '@/components/atoms/CustomCheckBox';
+import CustomLabel from '@/components/atoms/CustomLabel';
+import CustomMessageArea from '@/components/atoms/CustomMessageArea';
+import CustomTextArea from '@/components/atoms/CustomTextArea';
+import CustomTextBox from '@/components/atoms/CustomTextBox';
+import Dialog, { DialogFooterLayout } from '@/components/molecules/Dialog';
+import { useLoadingOverlay } from '@/contexts/LoadingOverlayContext';
+import type { LayoutMode } from '@/lib/hooks/useResponsiveLayoutMode';
+import {
+  createMaintenanceRecord,
+  deleteMaintenanceRecord,
+  fetchMaintenanceList,
+  getGameManagementErrorMessage,
+  updateMaintenanceRecord,
+} from '@/lib/game-management/api';
+import { extractProblemFieldErrors } from '@/lib/game-management/api/core';
+import {
+  buildMaintenanceSummaryText,
+  formatMaintenanceDate,
+} from '@/lib/game-management/maintenance';
+import type {
+  CreateGameConsoleMaintenanceRequest,
+  CreateGameSoftwareMaintenanceRequest,
+  CreateMemoryCardMaintenanceRequest,
+  GameConsoleMaintenanceDto,
+  GameSoftwareMaintenanceDto,
+  MaintenanceSummaryDto,
+  UpdateGameConsoleMaintenanceRequest,
+  UpdateGameSoftwareMaintenanceRequest,
+  UpdateMemoryCardMaintenanceRequest,
+  MemoryCardMaintenanceDto,
+} from '@/lib/game-management/types';
+import resources from '@/lib/resources';
+
+export type MaintenanceResourceKey = 'game-consoles' | 'game-softwares' | 'memory-cards';
+
+type MaintenanceRecord = GameConsoleMaintenanceDto | GameSoftwareMaintenanceDto | MemoryCardMaintenanceDto;
+
+type MaintenancePayload =
+  | CreateGameConsoleMaintenanceRequest
+  | CreateGameSoftwareMaintenanceRequest
+  | CreateMemoryCardMaintenanceRequest
+  | UpdateGameConsoleMaintenanceRequest
+  | UpdateGameSoftwareMaintenanceRequest
+  | UpdateMemoryCardMaintenanceRequest;
+
+type MaintenanceFormState = {
+  maintenanceDate: string;
+  isPowerOnPerformed: boolean;
+  isStartupConfirmed: boolean;
+  memo: string;
+};
+
+function getTodayDateString(): string {
+  const now = new Date();
+  const shifted = new Date(now.getTime() - now.getTimezoneOffset() * 60000);
+  return shifted.toISOString().slice(0, 10);
+}
+
+function createEmptyFormState(): MaintenanceFormState {
+  return {
+    maintenanceDate: getTodayDateString(),
+    isPowerOnPerformed: true,
+    isStartupConfirmed: true,
+    memo: '',
+  };
+}
+
+function buildFormState(record: MaintenanceRecord): MaintenanceFormState {
+  return {
+    maintenanceDate: record.maintenanceDate.slice(0, 10),
+    isPowerOnPerformed: record.isPowerOnPerformed,
+    isStartupConfirmed: record.isStartupConfirmed,
+    memo: record.memo ?? '',
+  };
+}
+
+function buildPayload(formState: MaintenanceFormState): MaintenancePayload {
+  return {
+    maintenanceDate: formState.maintenanceDate,
+    isPowerOnPerformed: formState.isPowerOnPerformed,
+    isStartupConfirmed: formState.isStartupConfirmed,
+    memo: formState.memo.trim() ? formState.memo.trim() : null,
+  };
+}
+
+function validateFormState(formState: MaintenanceFormState): Record<string, string[]> {
+  const errors: Record<string, string[]> = {};
+  const appendError = (field: keyof MaintenanceFormState, message: string) => {
+    errors[field] = [...(errors[field] ?? []), message];
+  };
+
+  if (!formState.maintenanceDate) {
+    appendError('maintenanceDate', '実施日を入力してください。');
+  } else if (formState.maintenanceDate > getTodayDateString()) {
+    appendError('maintenanceDate', '未来日は指定できません。');
+  }
+
+  if (!formState.isPowerOnPerformed && !formState.isStartupConfirmed) {
+    appendError('isPowerOnPerformed', '通電または起動確認のどちらかは実施してください。');
+    appendError('isStartupConfirmed', '通電または起動確認のどちらかは実施してください。');
+  }
+
+  if (formState.isStartupConfirmed && !formState.isPowerOnPerformed) {
+    appendError('isPowerOnPerformed', '起動確認を行う場合は通電も実施してください。');
+  }
+
+  return errors;
+}
+
+function getRecordStatusLabel(record: MaintenanceRecord): string {
+  if (record.isStartupConfirmed) {
+    return '起動確認済み';
+  }
+
+  if (record.isPowerOnPerformed) {
+    return '通電のみ';
+  }
+
+  return '未実施';
+}
+
+function FieldError({ messages }: { messages?: string[] }) {
+  if (!messages || messages.length === 0) {
+    return null;
+  }
+
+  return (
+    <p className="text-sm text-red-600 dark:text-red-400">
+      {messages.join(' ')}
+    </p>
+  );
+}
+
+export default function MaintenanceRecordsSection({
+  resourceKey,
+  parentId,
+  summary,
+  readOnly = false,
+  trialMode = false,
+  autoOpenCreateOnMount = false,
+  layoutMode = 'desktop',
+  onChanged,
+  onSaved,
+}: {
+  resourceKey: MaintenanceResourceKey;
+  parentId: number;
+  summary?: MaintenanceSummaryDto;
+  readOnly?: boolean;
+  trialMode?: boolean;
+  autoOpenCreateOnMount?: boolean;
+  layoutMode?: LayoutMode;
+  onChanged: () => void;
+  onSaved?: (mode: 'create' | 'update') => void;
+}) {
+  const { startLoading } = useLoadingOverlay();
+  const autoOpenedRef = useRef(false);
+  const [records, setRecords] = useState<MaintenanceRecord[]>([]);
+  const [loading, setLoading] = useState(!trialMode);
+  const [error, setError] = useState<string | null>(null);
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editingRecord, setEditingRecord] = useState<MaintenanceRecord | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<MaintenanceRecord | null>(null);
+  const [formState, setFormState] = useState<MaintenanceFormState>(createEmptyFormState());
+  const [formErrors, setFormErrors] = useState<Record<string, string[]>>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitSuccess, setSubmitSuccess] = useState<string | null>(null);
+
+  const loadRecords = useCallback(async () => {
+    if (trialMode) {
+      setRecords([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const nextRecords = await fetchMaintenanceList(resourceKey, parentId);
+      setRecords(nextRecords);
+    } catch (loadError) {
+      setError(getGameManagementErrorMessage(loadError, {
+        fallback: resources.gameManagement.errors.detailLoad,
+      }));
+    } finally {
+      setLoading(false);
+    }
+  }, [parentId, resourceKey, trialMode]);
+
+  useEffect(() => {
+    void loadRecords();
+  }, [loadRecords]);
+
+  const openCreateDialog = useCallback(() => {
+    setEditingRecord(null);
+    setFormState(createEmptyFormState());
+    setFormErrors({});
+    setSubmitError(null);
+    setSubmitSuccess(null);
+    setEditorOpen(true);
+  }, []);
+
+  const openEditDialog = useCallback((record: MaintenanceRecord) => {
+    setEditingRecord(record);
+    setFormState(buildFormState(record));
+    setFormErrors({});
+    setSubmitError(null);
+    setSubmitSuccess(null);
+    setEditorOpen(true);
+  }, []);
+
+  const closeEditorDialog = useCallback(() => {
+    setEditorOpen(false);
+    setEditingRecord(null);
+    setFormErrors({});
+    setSubmitError(null);
+    setSubmitSuccess(null);
+  }, []);
+
+  useEffect(() => {
+    if (!autoOpenCreateOnMount || readOnly || trialMode || autoOpenedRef.current) {
+      return;
+    }
+
+    autoOpenedRef.current = true;
+    openCreateDialog();
+  }, [autoOpenCreateOnMount, openCreateDialog, readOnly, trialMode]);
+
+  const submitLabel = editingRecord ? '更新する' : '記録を追加';
+
+  const maintenanceSummaryText = useMemo(
+    () => buildMaintenanceSummaryText(summary),
+    [summary],
+  );
+
+  const handleSave = useCallback(async () => {
+    const nextFormErrors = validateFormState(formState);
+    if (Object.keys(nextFormErrors).length > 0) {
+      setFormErrors(nextFormErrors);
+      setSubmitError(resources.gameManagement.validation.inputIncomplete);
+      return;
+    }
+
+    setFormErrors({});
+    setSubmitError(null);
+    setSubmitSuccess(null);
+
+    try {
+      await startLoading(async () => {
+        const payload = buildPayload(formState);
+        if (editingRecord) {
+          await updateMaintenanceRecord(resourceKey, parentId, editingRecord.id, payload);
+        } else {
+          await createMaintenanceRecord(resourceKey, parentId, payload);
+        }
+      }, editingRecord ? '保守記録を更新中...' : '保守記録を保存中...');
+
+      setSubmitSuccess(editingRecord ? '保守記録を更新しました。' : '保守記録を追加しました。');
+      await loadRecords();
+      onChanged();
+      onSaved?.(editingRecord ? 'update' : 'create');
+      closeEditorDialog();
+    } catch (saveError) {
+      const details = saveError instanceof Error && 'details' in saveError
+        ? (saveError as Error & { details?: unknown }).details
+        : undefined;
+      const nextServerErrors = extractProblemFieldErrors(details);
+      setFormErrors(nextServerErrors);
+      setSubmitError(getGameManagementErrorMessage(saveError, {
+        fallback: resources.gameManagement.errors.save,
+      }));
+    }
+  }, [closeEditorDialog, editingRecord, formState, loadRecords, onChanged, onSaved, parentId, resourceKey, startLoading]);
+
+  const handleDelete = useCallback(async () => {
+    if (!deleteTarget) {
+      return;
+    }
+
+    try {
+      await startLoading(async () => {
+        await deleteMaintenanceRecord(resourceKey, parentId, deleteTarget.id);
+      }, '保守記録を削除中...');
+
+      setDeleteTarget(null);
+      await loadRecords();
+      onChanged();
+    } catch (deleteError) {
+      setDeleteTarget(null);
+      setError(getGameManagementErrorMessage(deleteError, {
+        fallback: resources.gameManagement.errors.delete,
+      }));
+    }
+  }, [deleteTarget, loadRecords, onChanged, parentId, resourceKey, startLoading]);
+
+  return (
+    <>
+      <section className="space-y-4 rounded-2xl border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900/60">
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+          <div className="space-y-2">
+            <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-100">保守記録</h3>
+            <p className="text-sm leading-6 text-zinc-500 dark:text-zinc-300">{maintenanceSummaryText}</p>
+          </div>
+          {!readOnly ? (
+            <CustomButton onClick={openCreateDialog} disabled={trialMode}>
+              記録を追加
+            </CustomButton>
+          ) : null}
+        </div>
+
+        {trialMode ? (
+          <CustomMessageArea variant="info">
+            トライアルモードでは保守履歴の閲覧と保存は利用できません。ログイン後に保守記録を管理してください。
+          </CustomMessageArea>
+        ) : null}
+        {error ? <CustomMessageArea variant="error">{error}</CustomMessageArea> : null}
+
+        {loading ? (
+          <p className="text-sm text-zinc-500 dark:text-zinc-300">保守記録を読み込んでいます...</p>
+        ) : trialMode ? (
+          <p className="text-sm text-zinc-500 dark:text-zinc-300">トライアルモードでは保守記録はまだ表示されません。</p>
+        ) : records.length === 0 ? (
+          <p className="text-sm text-zinc-500 dark:text-zinc-300">保守記録はまだありません。</p>
+        ) : (
+          <div className="space-y-3">
+            {records.map((record) => (
+              <article key={record.id} className="space-y-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-950">
+                <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                  <div className="space-y-1">
+                    <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                      {formatMaintenanceDate(record.maintenanceDate)} / {getRecordStatusLabel(record)}
+                    </p>
+                    <p className="text-sm text-zinc-500 dark:text-zinc-300">
+                      通電: {record.isPowerOnPerformed ? '実施' : '未実施'} / 起動確認: {record.isStartupConfirmed ? '成功' : '未確認'}
+                    </p>
+                    {record.memo ? (
+                      <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-200">{record.memo}</p>
+                    ) : null}
+                  </div>
+                  {!readOnly ? (
+                    <div className="flex flex-wrap gap-2">
+                      <CustomButton variant="neutral" onClick={() => openEditDialog(record)}>
+                        編集
+                      </CustomButton>
+                      <CustomButton variant="ghost" onClick={() => setDeleteTarget(record)}>
+                        削除
+                      </CustomButton>
+                    </div>
+                  ) : null}
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <Dialog
+        open={editorOpen}
+        onClose={closeEditorDialog}
+        title={editingRecord ? '保守記録を編集' : '保守記録を追加'}
+        size="md"
+        footer={(
+          <DialogFooterLayout
+            layoutMode={layoutMode}
+            status={submitSuccess ? <CustomMessageArea variant="success">{submitSuccess}</CustomMessageArea> : null}
+            trailing={(
+              <>
+                <CustomButton variant="neutral" onClick={closeEditorDialog}>
+                  キャンセル
+                </CustomButton>
+                <CustomButton onClick={() => void handleSave()}>
+                  {submitLabel}
+                </CustomButton>
+              </>
+            )}
+          />
+        )}
+      >
+        <div className="space-y-5">
+          {submitError ? <CustomMessageArea variant="error">{submitError}</CustomMessageArea> : null}
+          <div className="space-y-2">
+            <CustomLabel htmlFor="maintenanceDate" required>実施日</CustomLabel>
+            <CustomTextBox
+              id="maintenanceDate"
+              type="date"
+              value={formState.maintenanceDate}
+              onChange={(event) => setFormState((current) => ({ ...current, maintenanceDate: event.target.value }))}
+              isError={Boolean(formErrors.maintenanceDate?.length)}
+            />
+            <FieldError messages={formErrors.maintenanceDate} />
+          </div>
+
+          <div className="space-y-3">
+            <CustomLabel>実施内容</CustomLabel>
+            <label className="flex items-start gap-3 rounded-xl border border-zinc-200 p-3 dark:border-zinc-800">
+              <CustomCheckBox
+                checked={formState.isPowerOnPerformed}
+                onChange={(event) => setFormState((current) => ({ ...current, isPowerOnPerformed: event.target.checked }))}
+              />
+              <span className="space-y-1 text-sm text-zinc-700 dark:text-zinc-200">
+                <span className="block font-medium">通電を実施</span>
+                <span className="block text-zinc-500 dark:text-zinc-300">電源投入まで行った場合はチェックしてください。</span>
+              </span>
+            </label>
+            <FieldError messages={formErrors.isPowerOnPerformed} />
+
+            <label className="flex items-start gap-3 rounded-xl border border-zinc-200 p-3 dark:border-zinc-800">
+              <CustomCheckBox
+                checked={formState.isStartupConfirmed}
+                onChange={(event) => setFormState((current) => ({ ...current, isStartupConfirmed: event.target.checked }))}
+              />
+              <span className="space-y-1 text-sm text-zinc-700 dark:text-zinc-200">
+                <span className="block font-medium">起動確認に成功</span>
+                <span className="block text-zinc-500 dark:text-zinc-300">タイトル画面到達など、正常起動を確認できた場合にチェックしてください。</span>
+              </span>
+            </label>
+            <FieldError messages={formErrors.isStartupConfirmed} />
+          </div>
+
+          <div className="space-y-2">
+            <CustomLabel htmlFor="maintenanceMemo">メモ</CustomLabel>
+            <CustomTextArea
+              id="maintenanceMemo"
+              value={formState.memo}
+              onChange={(event) => setFormState((current) => ({ ...current, memo: event.target.value }))}
+              placeholder="症状や作業内容など"
+            />
+            <FieldError messages={formErrors.memo} />
+          </div>
+        </div>
+      </Dialog>
+
+      <Dialog
+        open={deleteTarget != null}
+        onClose={() => setDeleteTarget(null)}
+        title="保守記録を削除"
+        size="sm"
+        footer={(
+          <DialogFooterLayout
+            layoutMode={layoutMode}
+            trailing={(
+              <>
+                <CustomButton variant="neutral" onClick={() => setDeleteTarget(null)}>
+                  キャンセル
+                </CustomButton>
+                <CustomButton variant="ghost" onClick={() => void handleDelete()}>
+                  削除する
+                </CustomButton>
+              </>
+            )}
+          />
+        )}
+      >
+        <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-300">
+          {deleteTarget
+            ? `${formatMaintenanceDate(deleteTarget.maintenanceDate)} の保守記録を削除します。`
+            : '保守記録を削除します。'}
+        </p>
+      </Dialog>
+    </>
+  );
+}

--- a/components/organisms/GameManagement/SaveDataSearchPage.tsx
+++ b/components/organisms/GameManagement/SaveDataSearchPage.tsx
@@ -1,0 +1,699 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import CustomButton from '@/components/atoms/CustomButton';
+import CustomCheckBox from '@/components/atoms/CustomCheckBox';
+import CustomComboBox from '@/components/atoms/CustomComboBox';
+import CustomLabel from '@/components/atoms/CustomLabel';
+import CustomMessageArea from '@/components/atoms/CustomMessageArea';
+import CustomTextBox from '@/components/atoms/CustomTextBox';
+import ResponsiveActionGroup from '@/components/molecules/ResponsiveActionGroup';
+import {
+  fetchAuthenticatedUserLookups,
+  fetchPublicMasterLookups,
+  fetchPublicSaveDataSchema,
+  fetchPublicStoryProgressSchema,
+  getGameManagementErrorMessage,
+} from '@/lib/game-management/api';
+import {
+  evaluateSaveDataSearch,
+  GAME_SOFTWARE_VARIANT_OPTIONS,
+  type SaveDataSearchFieldCondition,
+  type SaveDataSearchGroup,
+} from '@/lib/game-management/save-data-search';
+import { formatSaveStorageType } from '@/lib/game-management/save-storage-type';
+import { buildTrialUserData } from '@/lib/game-management/trial';
+import type {
+  ManagementLookups,
+  SaveDataSchemaDto,
+  StoryProgressSchemaDto,
+} from '@/lib/game-management/types';
+import { useResponsiveLayoutMode } from '@/lib/hooks/useResponsiveLayoutMode';
+import resources from '@/lib/resources';
+import { getResourceDefinition } from '@/lib/game-management/resources';
+import EditorDialog from './EditorDialog';
+import {
+  getAccountDisplay,
+  getGameConsoleDisplay,
+  getGameSoftwareDisplay,
+  getGameSoftwareMasterName,
+  getMemoryCardDisplay,
+} from './helpers';
+import { PageCard, PageFrame, TrialBanner } from './shared';
+
+type SearchGroupFormState = {
+  id: string;
+  gameSoftwareMasterId: string;
+  storyProgressDefinitionId: string;
+  fieldConditions: Array<SaveDataSearchFieldCondition & { id: string }>;
+};
+
+type SubmittedSearchState = {
+  variant: string;
+  groups: SearchGroupFormState[];
+};
+
+function createFieldCondition(): SaveDataSearchFieldCondition & { id: string } {
+  return {
+    id: `condition-${Math.random().toString(36).slice(2, 10)}`,
+    fieldKey: '',
+    value: '',
+  };
+}
+
+function createSearchGroup(): SearchGroupFormState {
+  return {
+    id: `group-${Math.random().toString(36).slice(2, 10)}`,
+    gameSoftwareMasterId: '',
+    storyProgressDefinitionId: '',
+    fieldConditions: [],
+  };
+}
+
+function cloneGroups(groups: SearchGroupFormState[]): SearchGroupFormState[] {
+  return groups.map((group) => ({
+    ...group,
+    fieldConditions: group.fieldConditions.map((condition) => ({ ...condition })),
+  }));
+}
+
+function getStorageSummary(saveData: ManagementLookups['saveDatas'][number], lookups: ManagementLookups): string {
+  switch (saveData.saveStorageType) {
+    case 0: {
+      const software = saveData.gameSoftwareId ? lookups.gameSoftwares.find((item) => item.id === saveData.gameSoftwareId) : null;
+      return software ? getGameSoftwareDisplay(software, lookups) : 'ゲームソフト';
+    }
+    case 1: {
+      const gameConsole = saveData.gameConsoleId ? lookups.gameConsoles.find((item) => item.id === saveData.gameConsoleId) : null;
+      return gameConsole ? getGameConsoleDisplay(gameConsole, lookups) : 'ゲーム機本体';
+    }
+    case 2: {
+      const account = saveData.accountId ? lookups.accounts.find((item) => item.id === saveData.accountId) : null;
+      const gameConsole = saveData.gameConsoleId ? lookups.gameConsoles.find((item) => item.id === saveData.gameConsoleId) : null;
+      return [account ? getAccountDisplay(account, lookups) : null, gameConsole ? getGameConsoleDisplay(gameConsole, lookups) : null]
+        .filter(Boolean)
+        .join(' / ');
+    }
+    case 3: {
+      const memoryCard = saveData.memoryCardId ? lookups.memoryCards.find((item) => item.id === saveData.memoryCardId) : null;
+      return memoryCard ? getMemoryCardDisplay(memoryCard, lookups) : 'メモリーカード';
+    }
+    default:
+      return '';
+  }
+}
+
+function buildSubmittedGroupSummary(
+  group: SearchGroupFormState,
+  schema: SaveDataSchemaDto | null | undefined,
+  storyProgressSchema: StoryProgressSchemaDto | null | undefined,
+  lookups: ManagementLookups,
+): string {
+  const parts = [
+    getGameSoftwareMasterName(Number(group.gameSoftwareMasterId), lookups),
+  ];
+
+  if (group.storyProgressDefinitionId) {
+    const storyProgress = storyProgressSchema?.choices.find((choice) => String(choice.storyProgressDefinitionId) === group.storyProgressDefinitionId);
+    parts.push(`進行度: ${storyProgress?.label ?? `#${group.storyProgressDefinitionId}`}`);
+  }
+
+  for (const condition of group.fieldConditions) {
+    const field = schema?.fields.find((item) => item.fieldKey === condition.fieldKey);
+    parts.push(`${field?.label ?? condition.fieldKey}: ${condition.value}`);
+  }
+
+  return parts.join(' / ');
+}
+
+export default function SaveDataSearchPage() {
+  const { data: session } = useSession();
+  const isTrial = !session?.user;
+  const layoutMode = useResponsiveLayoutMode();
+  const [lookups, setLookups] = useState<ManagementLookups | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [variant, setVariant] = useState('');
+  const [groups, setGroups] = useState<SearchGroupFormState[]>([createSearchGroup()]);
+  const [submittedSearch, setSubmittedSearch] = useState<SubmittedSearchState | null>(null);
+  const [saveDataSchemas, setSaveDataSchemas] = useState<Record<number, SaveDataSchemaDto>>({});
+  const [storyProgressSchemas, setStoryProgressSchemas] = useState<Record<number, StoryProgressSchemaDto>>({});
+  const [schemaLoadErrors, setSchemaLoadErrors] = useState<Record<number, string>>({});
+  const [schemaLoadingIds, setSchemaLoadingIds] = useState<number[]>([]);
+  const [editorRecordId, setEditorRecordId] = useState<number | null>(null);
+  const [pageMode, setPageMode] = useState<'view' | 'edit'>('view');
+
+  const saveDataDefinition = useMemo(() => getResourceDefinition('save-datas'), []);
+
+  const resetSchemaState = useCallback((gameSoftwareMasterId?: number) => {
+    setSaveDataSchemas((current) => {
+      if (gameSoftwareMasterId == null) {
+        return {};
+      }
+
+      const rest = { ...current };
+      delete rest[gameSoftwareMasterId];
+      return rest;
+    });
+    setStoryProgressSchemas((current) => {
+      if (gameSoftwareMasterId == null) {
+        return {};
+      }
+
+      const rest = { ...current };
+      delete rest[gameSoftwareMasterId];
+      return rest;
+    });
+    setSchemaLoadErrors((current) => {
+      if (gameSoftwareMasterId == null) {
+        return {};
+      }
+
+      const rest = { ...current };
+      delete rest[gameSoftwareMasterId];
+      return rest;
+    });
+    setSchemaLoadingIds((current) => (
+      gameSoftwareMasterId == null
+        ? []
+        : current.filter((id) => id !== gameSoftwareMasterId)
+    ));
+  }, []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const result = isTrial
+        ? { ...await fetchPublicMasterLookups(), ...buildTrialUserData() }
+        : await fetchAuthenticatedUserLookups();
+      setLookups(result);
+    } catch (loadError) {
+      setError(getGameManagementErrorMessage(loadError, {
+        fallback: resources.gameManagement.errors.listLoad,
+      }));
+    } finally {
+      setLoading(false);
+    }
+  }, [isTrial]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleReload = useCallback(() => {
+    resetSchemaState();
+    void load();
+  }, [load, resetSchemaState]);
+
+  const requestedMasterIds = useMemo(() => Array.from(new Set(
+    groups
+      .map((group) => Number(group.gameSoftwareMasterId))
+      .filter((value) => Number.isInteger(value) && value > 0),
+  )), [groups]);
+
+  useEffect(() => {
+    const pendingIds = requestedMasterIds.filter((id) => !saveDataSchemas[id] && !schemaLoadingIds.includes(id) && !schemaLoadErrors[id]);
+    if (pendingIds.length === 0) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadSchemas = async () => {
+      setSchemaLoadingIds((current) => Array.from(new Set([...current, ...pendingIds])));
+
+      const results = await Promise.allSettled(pendingIds.map(async (gameSoftwareMasterId) => ({
+        gameSoftwareMasterId,
+        saveDataSchema: await fetchPublicSaveDataSchema(gameSoftwareMasterId),
+        storyProgressSchema: await fetchPublicStoryProgressSchema(gameSoftwareMasterId),
+      })));
+
+      if (cancelled) {
+        return;
+      }
+
+      const nextSchemaErrors: Record<number, string> = {};
+      const nextSaveDataSchemas: Record<number, SaveDataSchemaDto> = {};
+      const nextStoryProgressSchemas: Record<number, StoryProgressSchemaDto> = {};
+
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          nextSaveDataSchemas[result.value.gameSoftwareMasterId] = result.value.saveDataSchema;
+          nextStoryProgressSchemas[result.value.gameSoftwareMasterId] = result.value.storyProgressSchema;
+          continue;
+        }
+
+        const rejectedId = pendingIds[results.indexOf(result)];
+        nextSchemaErrors[rejectedId] = getGameManagementErrorMessage(result.reason, {
+          fallback: resources.gameManagement.errors.schemaLoad,
+        });
+      }
+
+      setSaveDataSchemas((current) => ({ ...current, ...nextSaveDataSchemas }));
+      setStoryProgressSchemas((current) => ({ ...current, ...nextStoryProgressSchemas }));
+      setSchemaLoadErrors((current) => ({ ...current, ...nextSchemaErrors }));
+      setSchemaLoadingIds((current) => current.filter((id) => !pendingIds.includes(id)));
+    };
+
+    void loadSchemas();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [requestedMasterIds, saveDataSchemas, schemaLoadErrors, schemaLoadingIds]);
+
+  const submittedCriteria = useMemo(() => {
+    if (!submittedSearch) {
+      return null;
+    }
+
+    const criteriaGroups: SaveDataSearchGroup[] = submittedSearch.groups.map((group) => ({
+      gameSoftwareMasterId: Number(group.gameSoftwareMasterId),
+      storyProgressDefinitionId: group.storyProgressDefinitionId ? Number(group.storyProgressDefinitionId) : null,
+      fieldConditions: group.fieldConditions.map((condition) => ({
+        fieldKey: condition.fieldKey,
+        value: condition.value,
+      })),
+    }));
+
+    return {
+      variant: submittedSearch.variant === '' ? null : Number(submittedSearch.variant) as 0 | 1,
+      groups: criteriaGroups,
+    };
+  }, [submittedSearch]);
+
+  const results = useMemo(() => {
+    if (!lookups || !submittedCriteria) {
+      return [];
+    }
+
+    return evaluateSaveDataSearch(lookups, saveDataSchemas, submittedCriteria);
+  }, [lookups, saveDataSchemas, submittedCriteria]);
+
+  const resultIds = useMemo(() => results.map((result) => result.saveData.id), [results]);
+
+  const validateSearch = useCallback(() => {
+    const errors: string[] = [];
+
+    groups.forEach((group, index) => {
+      if (!group.gameSoftwareMasterId) {
+        errors.push(`条件グループ ${index + 1}: ゲームソフトマスタを選択してください。`);
+      }
+
+      if (group.gameSoftwareMasterId) {
+        const masterId = Number(group.gameSoftwareMasterId);
+        if (schemaLoadingIds.includes(masterId)) {
+          errors.push(`条件グループ ${index + 1}: スキーマ読込が完了してから検索してください。`);
+        }
+        if (schemaLoadErrors[masterId]) {
+          errors.push(`条件グループ ${index + 1}: ${schemaLoadErrors[masterId]}`);
+        }
+      }
+
+      group.fieldConditions.forEach((condition) => {
+        if (!condition.fieldKey) {
+          errors.push(`条件グループ ${index + 1}: schema 項目を選択してください。`);
+          return;
+        }
+
+        if (!condition.value.trim()) {
+          errors.push(`条件グループ ${index + 1}: schema 条件の値を入力してください。`);
+        }
+      });
+    });
+
+    return errors;
+  }, [groups, schemaLoadErrors, schemaLoadingIds]);
+
+  const handleSearch = useCallback(() => {
+    const validationErrors = validateSearch();
+    if (validationErrors.length > 0) {
+      setSearchError(validationErrors.join('\n'));
+      return;
+    }
+
+    setSearchError(null);
+    setSubmittedSearch({
+      variant,
+      groups: cloneGroups(groups),
+    });
+  }, [groups, validateSearch, variant]);
+
+  const updateGroup = useCallback((groupId: string, updater: (group: SearchGroupFormState) => SearchGroupFormState) => {
+    setGroups((current) => current.map((group) => (group.id === groupId ? updater(group) : group)));
+  }, []);
+
+  return (
+    <PageFrame
+      eyebrowLabel="Game Library"
+      title="横断セーブデータ検索"
+      description="共通 variant と複数の schema 条件グループを組み合わせ、セーブデータを作品横断で検索します。"
+      layoutMode={layoutMode}
+      actions={(
+        <>
+          <ResponsiveActionGroup layoutMode={layoutMode} mobileColumns={1}>
+            <Link href="/game-library" className="text-sm font-medium text-zinc-600 underline-offset-2 hover:underline dark:text-zinc-300">
+              ダッシュボードへ戻る
+            </Link>
+          </ResponsiveActionGroup>
+          <ResponsiveActionGroup layoutMode={layoutMode} mobileColumns={1} align="end">
+            <CustomButton variant="accent" onClick={handleSearch}>
+              検索する
+            </CustomButton>
+            <CustomButton onClick={handleReload}>
+              再読み込み
+            </CustomButton>
+          </ResponsiveActionGroup>
+        </>
+      )}
+    >
+      {isTrial ? <TrialBanner /> : null}
+      {error ? <CustomMessageArea variant="error">{error}</CustomMessageArea> : null}
+      {searchError ? <CustomMessageArea variant="error" className="whitespace-pre-line">{searchError}</CustomMessageArea> : null}
+      <PageCard>
+        {loading ? (
+          <p className="text-sm text-zinc-500 dark:text-zinc-300">検索対象を読み込んでいます...</p>
+        ) : !lookups ? null : (
+          <div className="space-y-6">
+            <section className="space-y-4 rounded-2xl border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900/60">
+              <div className="space-y-2">
+                <CustomLabel htmlFor="save-data-search-variant">共通フィルタ: variant</CustomLabel>
+                <CustomComboBox
+                  id="save-data-search-variant"
+                  value={variant}
+                  onChange={(event) => setVariant(event.target.value)}
+                >
+                  {GAME_SOFTWARE_VARIANT_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>{option.label}</option>
+                  ))}
+                </CustomComboBox>
+              </div>
+              <p className="text-sm leading-6 text-zinc-500 dark:text-zinc-300">
+                variant は全条件グループへ AND で適用されます。条件グループ同士は OR、各グループ内はゲームソフトマスタ / 進行度 / schema 項目を AND で評価します。
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">条件グループ</h2>
+                  <p className="text-sm text-zinc-500 dark:text-zinc-300">異なるゲームソフトマスタをまたいだ OR 検索を定義できます。</p>
+                </div>
+                <CustomButton onClick={() => setGroups((current) => [...current, createSearchGroup()])}>
+                  条件グループを追加
+                </CustomButton>
+              </div>
+
+              {groups.map((group, index) => {
+                const selectedMasterId = Number(group.gameSoftwareMasterId);
+                const schema = Number.isInteger(selectedMasterId) && selectedMasterId > 0 ? saveDataSchemas[selectedMasterId] : undefined;
+                const storyProgressSchema = Number.isInteger(selectedMasterId) && selectedMasterId > 0 ? storyProgressSchemas[selectedMasterId] : undefined;
+                const schemaError = Number.isInteger(selectedMasterId) && selectedMasterId > 0 ? schemaLoadErrors[selectedMasterId] : undefined;
+                const schemaLoading = Number.isInteger(selectedMasterId) && selectedMasterId > 0 ? schemaLoadingIds.includes(selectedMasterId) : false;
+
+                return (
+                  <article key={group.id} className="space-y-4 rounded-2xl border border-zinc-200 p-4 dark:border-zinc-800">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                      <div>
+                        <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-100">条件グループ {index + 1}</h3>
+                        <p className="text-sm text-zinc-500 dark:text-zinc-300">このグループ内の条件はすべて AND で評価されます。</p>
+                      </div>
+                      {groups.length > 1 ? (
+                        <CustomButton
+                          variant="ghost"
+                          onClick={() => setGroups((current) => current.filter((item) => item.id !== group.id))}
+                        >
+                          このグループを削除
+                        </CustomButton>
+                      ) : null}
+                    </div>
+
+                    <div className="grid gap-4 lg:grid-cols-2">
+                      <div className="space-y-2">
+                        <CustomLabel htmlFor={`${group.id}-master`}>ゲームソフトマスタ</CustomLabel>
+                        <CustomComboBox
+                          id={`${group.id}-master`}
+                          value={group.gameSoftwareMasterId}
+                          onChange={(event) => updateGroup(group.id, () => ({
+                            ...group,
+                            gameSoftwareMasterId: event.target.value,
+                            storyProgressDefinitionId: '',
+                            fieldConditions: [],
+                          }))}
+                        >
+                          <option value="">選択してください</option>
+                          {lookups.gameSoftwareMasters.map((master) => (
+                            <option key={master.id} value={String(master.id)}>
+                              {master.name}
+                            </option>
+                          ))}
+                        </CustomComboBox>
+                      </div>
+                      <div className="space-y-2">
+                        <CustomLabel htmlFor={`${group.id}-story-progress`}>ストーリー進行度（任意）</CustomLabel>
+                        <CustomComboBox
+                          id={`${group.id}-story-progress`}
+                          value={group.storyProgressDefinitionId}
+                          onChange={(event) => updateGroup(group.id, (current) => ({ ...current, storyProgressDefinitionId: event.target.value }))}
+                          disabled={!group.gameSoftwareMasterId || schemaLoading || Boolean(schemaError)}
+                        >
+                          <option value="">すべて</option>
+                          {(storyProgressSchema?.choices ?? []).map((choice) => (
+                            <option key={choice.storyProgressDefinitionId} value={String(choice.storyProgressDefinitionId)} disabled={choice.isDisabled}>
+                              {choice.label}
+                            </option>
+                          ))}
+                        </CustomComboBox>
+                      </div>
+                    </div>
+
+                    {schemaLoading ? <CustomMessageArea variant="info">スキーマを読み込んでいます...</CustomMessageArea> : null}
+                    {schemaError ? (
+                      <CustomMessageArea variant="error">
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                          <span>{schemaError}</span>
+                          <CustomButton
+                            variant="ghost"
+                            onClick={() => resetSchemaState(selectedMasterId)}
+                          >
+                            スキーマを再試行
+                          </CustomButton>
+                        </div>
+                      </CustomMessageArea>
+                    ) : null}
+
+                    <div className="space-y-3">
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                          <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">schema 条件</p>
+                          <p className="text-sm text-zinc-500 dark:text-zinc-300">0 件以上追加できます。</p>
+                        </div>
+                        <CustomButton
+                          disabled={!schema || schema.fields.filter((field) => !field.isDisabled).length === 0}
+                          onClick={() => updateGroup(group.id, (current) => ({
+                            ...current,
+                            fieldConditions: [...current.fieldConditions, createFieldCondition()],
+                          }))}
+                        >
+                          条件を追加
+                        </CustomButton>
+                      </div>
+
+                      {group.fieldConditions.length === 0 ? (
+                        <p className="text-sm text-zinc-500 dark:text-zinc-300">schema 条件なしでも検索できます。</p>
+                      ) : group.fieldConditions.map((condition) => {
+                        const selectedField = schema?.fields.find((field) => field.fieldKey === condition.fieldKey && !field.isDisabled);
+
+                        return (
+                          <div key={condition.id} className="grid gap-3 rounded-xl border border-zinc-200 p-3 dark:border-zinc-800 lg:grid-cols-[minmax(0,16rem)_minmax(0,1fr)_auto] lg:items-end">
+                            <div className="space-y-2">
+                              <CustomLabel htmlFor={`${condition.id}-field`}>項目</CustomLabel>
+                              <CustomComboBox
+                                id={`${condition.id}-field`}
+                                value={condition.fieldKey}
+                                onChange={(event) => updateGroup(group.id, (current) => ({
+                                  ...current,
+                                  fieldConditions: current.fieldConditions.map((item) => (
+                                    item.id === condition.id
+                                      ? { ...item, fieldKey: event.target.value, value: '' }
+                                      : item
+                                  )),
+                                }))}
+                              >
+                                <option value="">選択してください</option>
+                                {(schema?.fields ?? []).filter((field) => !field.isDisabled).map((field) => (
+                                  <option key={field.fieldKey} value={field.fieldKey}>{field.label}</option>
+                                ))}
+                              </CustomComboBox>
+                            </div>
+                            <div className="space-y-2">
+                              <CustomLabel htmlFor={`${condition.id}-value`}>値</CustomLabel>
+                              {selectedField?.fieldType === 4 ? (
+                                <div className="flex items-center gap-3 rounded-xl border border-zinc-200 px-3 py-2 dark:border-zinc-800">
+                                  <CustomCheckBox
+                                    checked={condition.value === 'true'}
+                                    onChange={(event) => updateGroup(group.id, (current) => ({
+                                      ...current,
+                                      fieldConditions: current.fieldConditions.map((item) => (
+                                        item.id === condition.id
+                                          ? { ...item, value: String(event.target.checked) }
+                                          : item
+                                      )),
+                                    }))}
+                                  />
+                                  <span className="text-sm text-zinc-700 dark:text-zinc-200">はい</span>
+                                </div>
+                              ) : selectedField?.fieldType === 6 ? (
+                                <CustomComboBox
+                                  id={`${condition.id}-value`}
+                                  value={condition.value}
+                                  onChange={(event) => updateGroup(group.id, (current) => ({
+                                    ...current,
+                                    fieldConditions: current.fieldConditions.map((item) => (
+                                      item.id === condition.id
+                                        ? { ...item, value: event.target.value }
+                                        : item
+                                    )),
+                                  }))}
+                                >
+                                  <option value="">選択してください</option>
+                                  {selectedField.options.map((option) => (
+                                    <option key={option.optionKey} value={option.optionKey}>{option.label}</option>
+                                  ))}
+                                </CustomComboBox>
+                              ) : (
+                                <CustomTextBox
+                                  id={`${condition.id}-value`}
+                                  type={selectedField?.fieldType === 5 ? 'date' : selectedField?.fieldType === 2 || selectedField?.fieldType === 3 ? 'number' : 'text'}
+                                  step={selectedField?.fieldType === 3 ? 'any' : undefined}
+                                  value={condition.value}
+                                  onChange={(event) => updateGroup(group.id, (current) => ({
+                                    ...current,
+                                    fieldConditions: current.fieldConditions.map((item) => (
+                                      item.id === condition.id
+                                        ? { ...item, value: event.target.value }
+                                        : item
+                                    )),
+                                  }))}
+                                  placeholder={selectedField?.fieldType === 0 || selectedField?.fieldType === 1 ? '部分一致' : '一致条件'}
+                                />
+                              )}
+                            </div>
+                            <CustomButton
+                              variant="ghost"
+                              onClick={() => updateGroup(group.id, (current) => ({
+                                ...current,
+                                fieldConditions: current.fieldConditions.filter((item) => item.id !== condition.id),
+                              }))}
+                            >
+                              条件を削除
+                            </CustomButton>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </article>
+                );
+              })}
+            </section>
+
+            <section className="space-y-4 rounded-2xl border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900/60">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">検索結果</h2>
+                  <p className="text-sm text-zinc-500 dark:text-zinc-300">
+                    {submittedSearch ? `${results.length} 件ヒットしました。` : '条件を入力して検索してください。'}
+                  </p>
+                </div>
+                {submittedSearch ? (
+                  <span className="text-sm text-zinc-500 dark:text-zinc-300">
+                    共通 variant: {GAME_SOFTWARE_VARIANT_OPTIONS.find((option) => option.value === submittedSearch.variant)?.label ?? 'すべて'}
+                  </span>
+                ) : null}
+              </div>
+
+              {submittedSearch && results.length === 0 ? (
+                <p className="text-sm text-zinc-500 dark:text-zinc-300">一致するセーブデータはありませんでした。</p>
+              ) : null}
+
+              <div className="space-y-3">
+                {submittedSearch ? results.map((result) => {
+                  const schema = saveDataSchemas[result.saveData.gameSoftwareMasterId];
+                  const storyProgressSchema = storyProgressSchemas[result.saveData.gameSoftwareMasterId];
+                  const matchedSummary = result.matchedGroupIndexes.map((groupIndex) => buildSubmittedGroupSummary(
+                    submittedSearch.groups[groupIndex]!,
+                    schema,
+                    storyProgressSchema,
+                    lookups,
+                  ));
+
+                  return (
+                    <article key={result.saveData.id} className="space-y-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-950">
+                      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                        <div className="space-y-2">
+                          <p className="text-base font-semibold text-zinc-900 dark:text-zinc-100">
+                            SaveData #{result.saveData.id} / {getGameSoftwareMasterName(result.saveData.gameSoftwareMasterId, lookups)}
+                          </p>
+                          <p className="text-sm text-zinc-500 dark:text-zinc-300">
+                            保存方式: {formatSaveStorageType(result.saveData.saveStorageType)} / 保存先: {getStorageSummary(result.saveData, lookups) || '未設定'}
+                          </p>
+                          <p className="text-sm text-zinc-500 dark:text-zinc-300">
+                            進行度: {result.saveData.storyProgressDefinitionId
+                              ? storyProgressSchema?.choices.find((choice) => choice.storyProgressDefinitionId === result.saveData.storyProgressDefinitionId)?.label ?? `#${result.saveData.storyProgressDefinitionId}`
+                              : '未設定'}
+                          </p>
+                          {result.saveData.memo ? (
+                            <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-200">{result.saveData.memo}</p>
+                          ) : null}
+                        </div>
+                        <CustomButton
+                          variant="neutral"
+                          onClick={() => {
+                            setPageMode('view');
+                            setEditorRecordId(result.saveData.id);
+                          }}
+                        >
+                          詳細を見る
+                        </CustomButton>
+                      </div>
+                      <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-3 text-sm text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900/60 dark:text-zinc-300">
+                        <p className="font-semibold text-zinc-800 dark:text-zinc-100">一致条件</p>
+                        <ul className="mt-2 space-y-1">
+                          {matchedSummary.map((summary, index) => (
+                            <li key={`${result.saveData.id}-${index}`}>- {summary}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    </article>
+                  );
+                }) : null}
+              </div>
+            </section>
+          </div>
+        )}
+      </PageCard>
+      {lookups && editorRecordId != null ? (
+        <EditorDialog
+          open
+          onClose={() => setEditorRecordId(null)}
+          resourceKey="save-datas"
+          definition={saveDataDefinition}
+          lookups={lookups}
+          isTrial={isTrial}
+          recordId={editorRecordId}
+          onRecordIdChange={setEditorRecordId}
+          rowIds={resultIds}
+          onDataChanged={() => { void load(); }}
+          pageMode={pageMode}
+          onPageModeChange={setPageMode}
+          layoutMode={layoutMode}
+        />
+      ) : null}
+    </PageFrame>
+  );
+}

--- a/components/organisms/GameManagement/index.tsx
+++ b/components/organisms/GameManagement/index.tsx
@@ -17,12 +17,14 @@ import {
 import RowMoveButtons from '@/components/organisms/GameManagement/RowMoveButtons';
 import { useLoadingOverlay } from '@/contexts/LoadingOverlayContext';
 import {
+  fetchCurrentUser,
   fetchMasterLookups,
   fetchPublicMasterLookups,
   fetchAuthenticatedUserLookups,
   getGameManagementErrorMessage,
   reorderResource,
 } from '@/lib/game-management/api';
+import { MAINTENANCE_FILTER_OPTIONS, supportsMaintenance } from '@/lib/game-management/maintenance';
 import resources from '@/lib/resources';
 import {
   fetchPublicSaveDataSchema,
@@ -40,6 +42,7 @@ import {
 } from '@/lib/game-management/trial';
 import { useResponsiveLayoutMode } from '@/lib/hooks/useResponsiveLayoutMode';
 import type {
+  MaintenanceHealthFilter,
   ManagementLookups,
   ResourceKey,
   SaveDataSchemaDto,
@@ -362,6 +365,7 @@ function ContentGroupChildTable({
 export function GameManagementDashboard({
     basePath = '/game-management',
     resourceKeys,
+    requiresAdmin = false,
     sectionLabel = 'Game Management',
     sectionTitle = 'ゲーム管理ダッシュボード',
     sectionDescription = '各マスタ、所有ゲーム機、ゲームソフト、アカウント、メモリーカード、セーブデータの一覧確認と編集画面への遷移をここから行えます。',
@@ -369,6 +373,7 @@ export function GameManagementDashboard({
   }: {
     basePath?: string;
     resourceKeys?: ResourceKey[];
+    requiresAdmin?: boolean;
     sectionLabel?: string;
     sectionTitle?: string;
     sectionDescription?: string;
@@ -376,7 +381,53 @@ export function GameManagementDashboard({
   }) {
     const { data: session } = useSession();
     const isTrial = !session?.user;
+    const [authError, setAuthError] = useState<string | null>(null);
+    const [authLoading, setAuthLoading] = useState(requiresAdmin && Boolean(session?.user));
     const displayKeys = resourceKeys ?? ADMIN_RESOURCE_ORDER;
+    const effectiveAuthError = requiresAdmin && session?.user ? authError : null;
+    const effectiveAuthLoading = requiresAdmin && session?.user ? authLoading : false;
+
+    useEffect(() => {
+      if (!requiresAdmin || !session?.user) {
+        return;
+      }
+
+      let cancelled = false;
+
+      void fetchCurrentUser()
+        .then((user) => {
+          if (cancelled) {
+            return;
+          }
+
+          if (!user.isAdmin && !user.effectiveRoles.includes('Admin')) {
+            setAuthError(getGameManagementErrorMessage(new Error('FORBIDDEN'), {
+              fallback: resources.gameManagement.errors.adminRequired,
+              adminFallback: resources.gameManagement.errors.adminRequired,
+            }));
+            return;
+          }
+
+          setAuthError(null);
+        })
+        .catch((error) => {
+          if (!cancelled) {
+            setAuthError(getGameManagementErrorMessage(error, {
+              fallback: resources.gameManagement.errors.detailLoad,
+              adminFallback: resources.gameManagement.errors.adminRequired,
+            }));
+          }
+        })
+        .finally(() => {
+          if (!cancelled) {
+            setAuthLoading(false);
+          }
+        });
+
+      return () => {
+        cancelled = true;
+      };
+    }, [requiresAdmin, session?.user]);
 
     return (
       <PageFrame
@@ -387,40 +438,47 @@ export function GameManagementDashboard({
         {isTrial && (
           <TrialBanner />
         )}
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {displayKeys.map((resourceKey) => {
-            const definition = RESOURCE_DEFINITIONS[resourceKey];
+        {effectiveAuthError ? <CustomMessageArea variant="error">{effectiveAuthError}</CustomMessageArea> : null}
+        {effectiveAuthLoading ? (
+          <PageCard>
+            <p className="text-sm text-zinc-500 dark:text-zinc-300">権限を確認しています...</p>
+          </PageCard>
+        ) : effectiveAuthError ? null : (
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {displayKeys.map((resourceKey) => {
+              const definition = RESOURCE_DEFINITIONS[resourceKey];
 
-            return (
+              return (
+                <Link
+                  key={resourceKey}
+                  href={`${basePath}/${resourceKey}`}
+                  className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm transition hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700"
+                >
+                  <div className="space-y-3">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">{definition.shortLabel}</p>
+                    <h2 className="text-lg font-semibold text-zinc-900 dark:text-white">{definition.label}</h2>
+                    <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-300">{definition.description}</p>
+                    <p className="text-sm font-semibold text-sky-700 dark:text-sky-300">一覧を開く</p>
+                  </div>
+                </Link>
+              );
+            })}
+            {extraCards.map((card) => (
               <Link
-                key={resourceKey}
-                href={`${basePath}/${resourceKey}`}
+                key={card.href}
+                href={card.href}
                 className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm transition hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700"
               >
                 <div className="space-y-3">
-                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">{definition.shortLabel}</p>
-                  <h2 className="text-lg font-semibold text-zinc-900 dark:text-white">{definition.label}</h2>
-                  <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-300">{definition.description}</p>
-                  <p className="text-sm font-semibold text-sky-700 dark:text-sky-300">一覧を開く</p>
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">{card.shortLabel}</p>
+                  <h2 className="text-lg font-semibold text-zinc-900 dark:text-white">{card.title}</h2>
+                  <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-300">{card.description}</p>
+                  <p className="text-sm font-semibold text-sky-700 dark:text-sky-300">{card.actionLabel ?? '画面を開く'}</p>
                 </div>
               </Link>
-            );
-          })}
-          {extraCards.map((card) => (
-            <Link
-              key={card.href}
-              href={card.href}
-              className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm transition hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700"
-            >
-              <div className="space-y-3">
-                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">{card.shortLabel}</p>
-                <h2 className="text-lg font-semibold text-zinc-900 dark:text-white">{card.title}</h2>
-                <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-300">{card.description}</p>
-                <p className="text-sm font-semibold text-sky-700 dark:text-sky-300">{card.actionLabel ?? '画面を開く'}</p>
-              </div>
-            </Link>
-          ))}
-        </div>
+            ))}
+          </div>
+        )}
       </PageFrame>
     );
   }
@@ -440,6 +498,7 @@ export function GameManagementDashboard({
     const [lookups, setLookups] = useState<ManagementLookups | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [loading, setLoading] = useState(true);
+    const [authLoading, setAuthLoading] = useState(scope === 'admin' && Boolean(session?.user));
     const [storyProgressLabels, setStoryProgressLabels] = useState<StoryProgressLabelMap>({});
     const [selectedContentGroupId, setSelectedContentGroupId] = useState('');
     const [saveDataSchemas, setSaveDataSchemas] = useState<Record<number, SaveDataSchemaDto>>({});
@@ -460,6 +519,7 @@ export function GameManagementDashboard({
     const [expandedRowKeys, setExpandedRowKeys] = useState<string[]>([]);
     const [selectedRowKeys, setSelectedRowKeys] = useState<string[]>([]);
     const [pageMode, setPageMode] = useState<PageMode>('view');
+    const [maintenanceHealthFilter, setMaintenanceHealthFilter] = useState<MaintenanceHealthFilter>('All');
     const layoutMode = useResponsiveLayoutMode();
     const [bulkEditorOpen, setBulkEditorOpen] = useState(false);
     const [bulkEditorTargetIds, setBulkEditorTargetIds] = useState<number[]>([]);
@@ -469,6 +529,7 @@ export function GameManagementDashboard({
 
   const load = useCallback(async () => {
     setLoading(true);
+    setAuthLoading(scope === 'admin' && Boolean(session?.user));
     setError(null);
     setSaveError(null);
     setIsDirty(false);
@@ -479,6 +540,10 @@ export function GameManagementDashboard({
     try {
       let result: ManagementLookups;
       if (scope === 'admin') {
+        const user = await fetchCurrentUser();
+        if (!user.isAdmin && !user.effectiveRoles.includes('Admin')) {
+          throw new Error('ADMIN_REQUIRED');
+        }
         const masters = await fetchMasterLookups();
         result = { ...masters, accounts: [], gameConsoles: [], gameSoftwares: [], memoryCards: [], saveDatas: [] };
       } else if (isTrial) {
@@ -486,7 +551,9 @@ export function GameManagementDashboard({
         const userData = buildTrialUserData();
         result = { ...masters, ...userData };
       } else {
-        result = await fetchAuthenticatedUserLookups();
+        result = await fetchAuthenticatedUserLookups({
+          maintenanceHealthFilter: supportsMaintenance(resourceKey) ? maintenanceHealthFilter : 'All',
+        });
       }
       setLookups(result);
     } catch (loadError) {
@@ -496,8 +563,9 @@ export function GameManagementDashboard({
       }));
     } finally {
       setLoading(false);
+      setAuthLoading(false);
     }
-  }, [isTrial, scope]);
+  }, [isTrial, maintenanceHealthFilter, resourceKey, scope, session?.user]);
 
   useEffect(() => {
     void load();
@@ -1162,10 +1230,31 @@ export function GameManagementDashboard({
       {saveError ? <CustomMessageArea variant="error">{saveError}</CustomMessageArea> : null}
       {isTrial && <TrialBanner />}
       <PageCard>
-        {loading ? (
-          <p className="text-sm text-zinc-500">一覧を読み込んでいます...</p>
+        {loading || authLoading ? (
+          <p className="text-sm text-zinc-500">{authLoading ? '権限を確認しています...' : '一覧を読み込んでいます...'}</p>
         ) : (
           <div className="space-y-4">
+            {supportsMaintenance(resourceKey) ? (
+              <div className="space-y-3 rounded-2xl border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900/60">
+                <div className="grid gap-3 md:grid-cols-[minmax(0,20rem)_1fr] md:items-end">
+                  <div className="space-y-2">
+                    <CustomLabel htmlFor="maintenance-health-filter">保守状態</CustomLabel>
+                    <CustomComboBox
+                      id="maintenance-health-filter"
+                      value={maintenanceHealthFilter}
+                      onChange={(event) => setMaintenanceHealthFilter(event.target.value as MaintenanceHealthFilter)}
+                    >
+                      {MAINTENANCE_FILTER_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>{option.label}</option>
+                      ))}
+                    </CustomComboBox>
+                  </div>
+                  <p className="text-sm leading-6 text-zinc-500 dark:text-zinc-300">
+                    最新の保守記録に基づいて一覧を絞り込みます。未確認は「起動不調を除外」に含まれ、期限超過は一覧の詳細表示で確認できます。
+                  </p>
+                </div>
+              </div>
+            ) : null}
             {resourceKey === 'save-datas' ? (
               <div className="space-y-3 rounded-2xl border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900/60">
                 <div className="grid gap-3 md:grid-cols-[minmax(0,20rem)_1fr] md:items-end">

--- a/components/organisms/GameManagement/shared.tsx
+++ b/components/organisms/GameManagement/shared.tsx
@@ -5,6 +5,7 @@ import CustomHeader from '@/components/atoms/CustomHeader';
 import CustomLabel from '@/components/atoms/CustomLabel';
 import ResponsiveActionGroup from '@/components/molecules/ResponsiveActionGroup';
 import type { LayoutMode } from '@/lib/hooks/useResponsiveLayoutMode';
+import { buildMaintenanceSummaryText } from '@/lib/game-management/maintenance';
 import { formatSaveStorageType } from '@/lib/game-management/save-storage-type';
 import type {
   AccountDto,
@@ -179,7 +180,7 @@ export function ResourceSummary({ resourceKey, record, lookups, storyProgressLab
     }
     case 'game-consoles': {
       const item = record as GameConsoleDto;
-      return <p className="select-none text-sm text-zinc-600 dark:text-zinc-300">対応マスタ: {getGameConsoleMasterName(item.gameConsoleMasterId, lookups)}</p>;
+      return <p className="select-none text-sm text-zinc-600 dark:text-zinc-300">対応マスタ: {getGameConsoleMasterName(item.gameConsoleMasterId, lookups)} / {buildMaintenanceSummaryText(item.maintenance)}</p>;
     }
     case 'game-software-masters': {
       const item = record as GameSoftwareMasterDto;
@@ -187,11 +188,11 @@ export function ResourceSummary({ resourceKey, record, lookups, storyProgressLab
     }
     case 'game-softwares': {
       const item = record as GameSoftwareDto;
-      return <p className="select-none text-sm text-zinc-600 dark:text-zinc-300">ソフトマスタ: {getGameSoftwareMasterName(item.gameSoftwareMasterId, lookups)}</p>;
+      return <p className="select-none text-sm text-zinc-600 dark:text-zinc-300">ソフトマスタ: {getGameSoftwareMasterName(item.gameSoftwareMasterId, lookups)} / {buildMaintenanceSummaryText(item.maintenance)}</p>;
     }
     case 'memory-cards': {
       const item = record as MemoryCardDto;
-      return <p className="select-none text-sm text-zinc-600 dark:text-zinc-300">所有者: {item.ownerGoogleUserId}</p>;
+      return <p className="select-none text-sm text-zinc-600 dark:text-zinc-300">所有者: {item.ownerGoogleUserId} / {buildMaintenanceSummaryText(item.maintenance)}</p>;
     }
     case 'save-datas': {
       const item = record as SaveDataDto;

--- a/components/organisms/GameManagement/table-rows.tsx
+++ b/components/organisms/GameManagement/table-rows.tsx
@@ -1,5 +1,6 @@
 import { formatSaveStorageType } from '@/lib/game-management/save-storage-type';
 import { formatMergedFieldValue, formatSaveDataFieldValueForList, mergeSchemaWithSaveData } from '@/lib/game-management/save-data-fields';
+import { buildMaintenanceSummaryText } from '@/lib/game-management/maintenance';
 import {
   formatDeletedState,
   getAccountDisplay,
@@ -242,7 +243,7 @@ export function buildTableRows(
         displayOrder: item.displayOrder,
         primary: getGameConsoleDisplay(item, lookups),
         relation: getGameConsoleMasterName(item.gameConsoleMasterId, lookups),
-        note: item.memo ?? '',
+        note: [buildMaintenanceSummaryText(item.maintenance), item.memo].filter(Boolean).join(' / '),
         status: formatDeletedState(item.isDeleted),
         edit: '編集',
       }));
@@ -296,6 +297,7 @@ export function buildTableRows(
           const console = item.installedGameConsoleId != null ? lookups.gameConsoles.find((c) => c.id === item.installedGameConsoleId) : undefined;
           if (console) noteParts.push(`インストール先: ${getGameConsoleDisplay(console, lookups)}`);
         }
+        noteParts.unshift(buildMaintenanceSummaryText(item.maintenance));
         if (item.memo) noteParts.push(item.memo);
         return {
           tableRowKey: createTableRowKey(resourceKey, item.id),
@@ -315,7 +317,7 @@ export function buildTableRows(
         displayOrder: item.displayOrder,
         primary: item.label || `MemoryCard #${item.id}`,
         relation: getMemoryCardEditionMasterName(item.memoryCardEditionMasterId, lookups),
-        note: item.memo ?? '',
+        note: [buildMaintenanceSummaryText(item.maintenance), item.memo].filter(Boolean).join(' / '),
         status: formatDeletedState(item.isDeleted),
         edit: '詳細',
       }));

--- a/docs/ISSUE_94_PHASE1_LIST_UI_MAINTENANCE_SEARCH.md
+++ b/docs/ISSUE_94_PHASE1_LIST_UI_MAINTENANCE_SEARCH.md
@@ -1,0 +1,82 @@
+# Issue #94 実装追従: Game Library 保守履歴と横断セーブデータ検索
+
+> 対象 Issue: #94
+> 対象範囲: `/game-library/maintenance`、`/game-library/save-data-search`、保守履歴ダイアログ UX、ダッシュボード導線、検索ヘルパー/テスト
+
+---
+
+## 概要
+
+Issue #94 の Phase 3 実装差分に合わせて、Game Library 向けの新規ルートと関連 UI の最終挙動を整理する。
+
+| 項目 | 実装内容 |
+|------|----------|
+| ダッシュボード導線 | `/game-library` に「保守履歴」「横断セーブデータ検索」のカードを追加 |
+| 保守ページ | `/game-library/maintenance` で 3 リソース横断の保守状態一覧と順次記録を提供 |
+| 検索ページ | `/game-library/save-data-search` で `variant` + 複数条件グループ検索を提供 |
+| ネストダイアログ | `EditorDialog` から保守履歴ダイアログを子表示し、変更後に親サマリーを再読込 |
+| テスト | 保守サマリー helper と横断検索 helper の unit test を追加 |
+
+---
+
+## 1. ルート構成
+
+| ルート | 役割 |
+|--------|------|
+| `/game-library` | ユーザー向けダッシュボード。既存管理対象に加えて 2 つの追加カードを表示 |
+| `/game-library/maintenance` | ゲーム機・ゲームソフト・メモリーカードを横断した保守対象一覧 |
+| `/game-library/save-data-search` | 作品横断のセーブデータ検索ページ |
+
+---
+
+## 2. 保守履歴 UI
+
+### `/game-library/maintenance`
+
+- `MaintenanceDashboardPage` を表示する
+- 保守状態フィルタは `All` / `ExcludeUnhealthy` / `OnlyUnhealthy`
+- 一覧は overdue、状態、次回予定日を基準に並べ替える
+- 複数選択した対象を「順次記録」で 1 件ずつダイアログ表示する
+- 自動遷移は **新規記録の保存時のみ** 次対象へ進む
+
+### `EditorDialog` のネストダイアログ
+
+- 保守対応リソースの編集ダイアログ内に「保守履歴」セクションを表示する
+- `[履歴を見る]` で子ダイアログを開き、`MaintenanceRecordsSection` を再利用する
+- 子ダイアログで変更が完了すると、親レコードを再取得して保守サマリーを更新する
+- trial mode では子ダイアログは開けるが、保守記録の保存は無効
+
+---
+
+## 3. 横断セーブデータ検索
+
+- 検索条件は `variant` の共通フィルタと、1 件以上の条件グループで構成する
+- 評価式は `variant AND (group1 OR group2 OR ...)`
+- 各グループは `gameSoftwareMasterId` 必須、`storyProgressDefinitionId` 任意、schema 条件 0 件以上
+- schema / story progress schema は、選択された `gameSoftwareMasterId` のみ遅延読込する
+- 検索結果はカード表示し、各結果に一致した条件グループ要約を表示する
+- 結果から `SaveData` 詳細ダイアログを **view mode** で開ける
+
+### schema 条件の評価
+
+| fieldType | 評価方法 |
+|-----------|----------|
+| 文字列 / 複数行文字列 | 部分一致 |
+| 真偽値 | `true` / `false` の完全一致 |
+| 数値 / 小数 / 日付 / 選択肢 | 完全一致 |
+
+---
+
+## 4. テスト反映
+
+| ファイル | 対象 |
+|---------|------|
+| `lib/game-management/maintenance.test.ts` | 保守対応判定、状態ラベル、保守サマリー文言 |
+| `lib/game-management/save-data-search.test.ts` | variant 判定、条件グループ一致、OR/AND 評価 |
+
+---
+
+## 5. 実装上の補足
+
+- 保守ページ・検索ページとも `PageFrame` / `PageCard` を再利用し、Game Library 配下の見た目を統一している
+- README のセットアップ手順や運用前提には変更がないため、本件では更新していない

--- a/lib/game-management/api/core.test.ts
+++ b/lib/game-management/api/core.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractProblemFieldErrors, extractServerDetail } from './problem-details';
+
+describe('game-management api error helpers', () => {
+  it('extracts field errors from validation problem details and structured error details', () => {
+    expect(extractProblemFieldErrors({
+      errors: {
+        MaintenanceDate: ['メンテナンス実施日は必須です。'],
+      },
+      errorDetails: [
+        {
+          code: 'INVALID_STARTUP',
+          field: 'IsPowerOnPerformed',
+          fieldLabel: '通電',
+          message: '起動確認を行う場合は通電も必要です。',
+          userMessage: '起動確認を行う場合は通電も必要です。',
+          suggestedAction: '通電を実施するか、起動確認を外してください。',
+        },
+      ],
+    })).toEqual({
+      maintenanceDate: ['メンテナンス実施日は必須です。'],
+      isPowerOnPerformed: ['起動確認を行う場合は通電も必要です。'],
+    });
+  });
+
+  it('prefers structured error details when building a user-facing error message', () => {
+    expect(extractServerDetail({
+      title: 'Validation Failed',
+      traceId: '00-abc-xyz-00',
+      errorDetails: [
+        {
+          code: 'INVALID_STARTUP',
+          fieldLabel: '起動確認',
+          message: '起動確認に失敗しました。',
+          userMessage: '起動確認に失敗しました。',
+          suggestedAction: '電源や接続状況を確認してください。',
+        },
+      ],
+    })).toBe([
+      '起動確認: 起動確認に失敗しました。',
+      '対応: 電源や接続状況を確認してください。',
+      'Trace ID: 00-abc-xyz-00',
+    ].join('\n'));
+  });
+});

--- a/lib/game-management/api/core.ts
+++ b/lib/game-management/api/core.ts
@@ -1,7 +1,12 @@
 import { createFrontendApiClient } from '@/lib/api/frontend-client';
 import resources from '@/lib/resources';
 import { getResourceDefinition } from '@/lib/game-management/resources';
-import type { MoveAccountBetweenConsolesRequest, ReorderItemRequest, ResourceKey } from '@/lib/game-management/types';
+import type {
+  MoveAccountBetweenConsolesRequest,
+  ReorderItemRequest,
+  ResourceKey,
+} from '@/lib/game-management/types';
+import { extractServerDetail } from './problem-details';
 
 const client = createFrontendApiClient('game-library-api');
 
@@ -39,19 +44,6 @@ export class ApiError extends Error {
 
 function formatMessageParts(title: string, detail?: string | null): string {
   return [title, detail].filter((value): value is string => Boolean(value)).join('\n');
-}
-
-export function extractServerDetail(details: unknown): string | null {
-  if (!details || typeof details !== 'object') return null;
-  const candidate = details as { detail?: string; title?: string; errors?: Record<string, string[]> };
-  if (candidate.detail) return candidate.detail;
-  if (candidate.errors) {
-    const lines = Object.entries(candidate.errors)
-      .flatMap(([key, values]) => values.map((value) => `${key}: ${value}`));
-    if (lines.length > 0) return lines.join('\n');
-  }
-  if (candidate.title) return candidate.title;
-  return null;
 }
 
 function getErrorMessage(details: unknown, fallback: string): string {
@@ -164,9 +156,31 @@ export async function unwrap<T>(promise: ReturnType<typeof client.get<T>>): Prom
 // Generic resource fetch
 // ---------------------------------------------------------------------------
 
-export async function fetchResourceList<T>(resourceKey: ResourceKey, includeDeleted = false): Promise<T[]> {
+export type FetchResourceListOptions = {
+  includeDeleted?: boolean;
+  query?: Record<string, string | number | boolean | null | undefined>;
+};
+
+export async function fetchResourceList<T>(
+  resourceKey: ResourceKey,
+  includeDeletedOrOptions: boolean | FetchResourceListOptions = false,
+): Promise<T[]> {
   const definition = getResourceDefinition(resourceKey);
-  return unwrap(client.get<T[]>(`${definition.apiPath}?includeDeleted=${includeDeleted}`));
+  const options = typeof includeDeletedOrOptions === 'boolean'
+    ? { includeDeleted: includeDeletedOrOptions }
+    : includeDeletedOrOptions;
+  const searchParams = new URLSearchParams();
+  searchParams.set('includeDeleted', String(options.includeDeleted ?? false));
+
+  for (const [key, value] of Object.entries(options.query ?? {})) {
+    if (value == null || value === '') {
+      continue;
+    }
+
+    searchParams.set(key, String(value));
+  }
+
+  return unwrap(client.get<T[]>(`${definition.apiPath}?${searchParams.toString()}`));
 }
 
 export async function fetchResourceById<T>(resourceKey: ResourceKey, id: string | number): Promise<T> {
@@ -216,3 +230,4 @@ export async function moveAccountBetweenConsoles(payload: MoveAccountBetweenCons
 
 export { client };
 export { getErrorMessage };
+export { extractProblemFieldErrors, extractServerDetail, getProblemDetails } from './problem-details';

--- a/lib/game-management/api/index.ts
+++ b/lib/game-management/api/index.ts
@@ -17,6 +17,14 @@ export {
 } from './compatibility';
 
 export {
+  fetchCurrentUser,
+  fetchMaintenanceList,
+  createMaintenanceRecord,
+  updateMaintenanceRecord,
+  deleteMaintenanceRecord,
+} from './maintenance';
+
+export {
   fetchMasterLookups,
   fetchUserLookups,
   fetchAuthenticatedUserLookups,

--- a/lib/game-management/api/lookups.ts
+++ b/lib/game-management/api/lookups.ts
@@ -9,6 +9,7 @@ import type {
   GameSoftwareContentGroupDto,
   GameSoftwareMasterDto,
   GameSoftwareDto,
+  MaintenanceHealthFilter,
   ManagementLookups,
   MasterLookups,
   MemoryCardEditionMasterDto,
@@ -17,6 +18,10 @@ import type {
 } from '@/lib/game-management/types';
 import { client, fetchResourceList, unwrap } from './core';
 import { fetchPublicMasterLookups } from './public';
+
+type UserLookupOptions = {
+  maintenanceHealthFilter?: MaintenanceHealthFilter;
+};
 
 // ---------------------------------------------------------------------------
 // Admin master lookups
@@ -45,7 +50,8 @@ export async function fetchMasterLookups(): Promise<MasterLookups> {
   return { accountTypeMasters, gameConsoleCategories, gameConsoleCategoryCompatibilities, gameConsoleMasters, gameConsoleEditionMasters, gameSoftwareContentGroups, gameSoftwareMasters, memoryCardEditionMasters };
 }
 
-export async function fetchUserLookups(): Promise<ManagementLookups> {
+export async function fetchUserLookups(options: UserLookupOptions = {}): Promise<ManagementLookups> {
+  const maintenanceHealthFilter = options.maintenanceHealthFilter ?? 'All';
   const [
     masterLookups,
     accounts,
@@ -56,9 +62,9 @@ export async function fetchUserLookups(): Promise<ManagementLookups> {
   ] = await Promise.all([
     fetchPublicMasterLookups(),
     fetchResourceList<AccountDto>('accounts'),
-    fetchResourceList<GameConsoleDto>('game-consoles'),
-    fetchResourceList<GameSoftwareDto>('game-softwares'),
-    fetchResourceList<MemoryCardDto>('memory-cards'),
+    fetchResourceList<GameConsoleDto>('game-consoles', { query: { maintenanceHealthFilter } }),
+    fetchResourceList<GameSoftwareDto>('game-softwares', { query: { maintenanceHealthFilter } }),
+    fetchResourceList<MemoryCardDto>('memory-cards', { query: { maintenanceHealthFilter } }),
     fetchResourceList<SaveDataDto>('save-datas'),
   ]);
   return {
@@ -75,7 +81,8 @@ export async function fetchUserLookups(): Promise<ManagementLookups> {
 // Authenticated user lookups (public masters + user data)
 // ---------------------------------------------------------------------------
 
-export async function fetchAuthenticatedUserLookups(): Promise<ManagementLookups> {
+export async function fetchAuthenticatedUserLookups(options: UserLookupOptions = {}): Promise<ManagementLookups> {
+  const maintenanceHealthFilter = options.maintenanceHealthFilter ?? 'All';
   const [
     masterLookups,
     accounts,
@@ -86,9 +93,9 @@ export async function fetchAuthenticatedUserLookups(): Promise<ManagementLookups
   ] = await Promise.all([
     fetchPublicMasterLookups(),
     fetchResourceList<AccountDto>('accounts'),
-    fetchResourceList<GameConsoleDto>('game-consoles'),
-    fetchResourceList<GameSoftwareDto>('game-softwares'),
-    fetchResourceList<MemoryCardDto>('memory-cards'),
+    fetchResourceList<GameConsoleDto>('game-consoles', { query: { maintenanceHealthFilter } }),
+    fetchResourceList<GameSoftwareDto>('game-softwares', { query: { maintenanceHealthFilter } }),
+    fetchResourceList<MemoryCardDto>('memory-cards', { query: { maintenanceHealthFilter } }),
     fetchResourceList<SaveDataDto>('save-datas'),
   ]);
   return {

--- a/lib/game-management/api/maintenance.ts
+++ b/lib/game-management/api/maintenance.ts
@@ -1,0 +1,81 @@
+import type {
+  CreateGameConsoleMaintenanceRequest,
+  CreateGameSoftwareMaintenanceRequest,
+  CreateMemoryCardMaintenanceRequest,
+  CurrentUserDto,
+  GameConsoleMaintenanceDto,
+  GameSoftwareMaintenanceDto,
+  MemoryCardMaintenanceDto,
+  UpdateGameConsoleMaintenanceRequest,
+  UpdateGameSoftwareMaintenanceRequest,
+  UpdateMemoryCardMaintenanceRequest,
+} from '@/lib/game-management/types';
+import { client, unwrap } from './core';
+
+type MaintenanceResourceKey = 'game-consoles' | 'game-softwares' | 'memory-cards';
+
+type MaintenanceDtoMap = {
+  'game-consoles': GameConsoleMaintenanceDto;
+  'game-softwares': GameSoftwareMaintenanceDto;
+  'memory-cards': MemoryCardMaintenanceDto;
+};
+
+type CreateMaintenanceRequestMap = {
+  'game-consoles': CreateGameConsoleMaintenanceRequest;
+  'game-softwares': CreateGameSoftwareMaintenanceRequest;
+  'memory-cards': CreateMemoryCardMaintenanceRequest;
+};
+
+type UpdateMaintenanceRequestMap = {
+  'game-consoles': UpdateGameConsoleMaintenanceRequest;
+  'game-softwares': UpdateGameSoftwareMaintenanceRequest;
+  'memory-cards': UpdateMemoryCardMaintenanceRequest;
+};
+
+const maintenanceApiPathMap: Record<MaintenanceResourceKey, string> = {
+  'game-consoles': '/api/GameConsoles',
+  'game-softwares': '/api/GameSoftwares',
+  'memory-cards': '/api/MemoryCards',
+};
+
+function buildMaintenancePath(resourceKey: MaintenanceResourceKey, parentId: number, maintenanceId?: number): string {
+  const basePath = `${maintenanceApiPathMap[resourceKey]}/${parentId}/Maintenances`;
+  return maintenanceId == null ? basePath : `${basePath}/${maintenanceId}`;
+}
+
+export async function fetchCurrentUser(): Promise<CurrentUserDto> {
+  return unwrap(client.get<CurrentUserDto>('/api/Auth/me'));
+}
+
+export async function fetchMaintenanceList<K extends MaintenanceResourceKey>(
+  resourceKey: K,
+  parentId: number,
+  includeDeleted = false,
+): Promise<Array<MaintenanceDtoMap[K]>> {
+  return unwrap(client.get<Array<MaintenanceDtoMap[K]>>(`${buildMaintenancePath(resourceKey, parentId)}?includeDeleted=${includeDeleted}`));
+}
+
+export async function createMaintenanceRecord<K extends MaintenanceResourceKey>(
+  resourceKey: K,
+  parentId: number,
+  payload: CreateMaintenanceRequestMap[K],
+): Promise<number> {
+  return unwrap(client.post<number>(buildMaintenancePath(resourceKey, parentId), payload));
+}
+
+export async function updateMaintenanceRecord<K extends MaintenanceResourceKey>(
+  resourceKey: K,
+  parentId: number,
+  maintenanceId: number,
+  payload: UpdateMaintenanceRequestMap[K],
+): Promise<MaintenanceDtoMap[K]> {
+  return unwrap(client.put<MaintenanceDtoMap[K]>(buildMaintenancePath(resourceKey, parentId, maintenanceId), payload));
+}
+
+export async function deleteMaintenanceRecord<K extends MaintenanceResourceKey>(
+  resourceKey: K,
+  parentId: number,
+  maintenanceId: number,
+): Promise<void> {
+  await unwrap(client.delete<void>(buildMaintenancePath(resourceKey, parentId, maintenanceId)));
+}

--- a/lib/game-management/api/problem-details.ts
+++ b/lib/game-management/api/problem-details.ts
@@ -1,0 +1,92 @@
+import type {
+  ProblemDetails,
+  ValidationProblemDetails,
+} from '@/lib/game-management/types';
+
+function normalizeFieldKey(fieldName: string): string {
+  if (!fieldName) {
+    return fieldName;
+  }
+
+  return `${fieldName.charAt(0).toLowerCase()}${fieldName.slice(1)}`;
+}
+
+function isProblemDetailsLike(details: unknown): details is ProblemDetails {
+  return details != null && typeof details === 'object';
+}
+
+export function getProblemDetails(details: unknown): ProblemDetails | ValidationProblemDetails | null {
+  if (!isProblemDetailsLike(details)) {
+    return null;
+  }
+
+  return details as ProblemDetails | ValidationProblemDetails;
+}
+
+export function extractProblemFieldErrors(details: unknown): Record<string, string[]> {
+  const candidate = getProblemDetails(details);
+  if (!candidate) {
+    return {};
+  }
+
+  const errorMap = new Map<string, string[]>();
+  const appendError = (fieldName: string | undefined, message: string | undefined) => {
+    if (!fieldName || !message) {
+      return;
+    }
+
+    const normalizedFieldName = normalizeFieldKey(fieldName);
+    const existing = errorMap.get(normalizedFieldName) ?? [];
+    if (!existing.includes(message)) {
+      existing.push(message);
+      errorMap.set(normalizedFieldName, existing);
+    }
+  };
+
+  const validationErrors = (candidate as ValidationProblemDetails).errors;
+  if (validationErrors) {
+    for (const [fieldName, messages] of Object.entries(validationErrors)) {
+      for (const message of messages) {
+        appendError(fieldName, message);
+      }
+    }
+  }
+
+  for (const detail of candidate.errorDetails ?? []) {
+    appendError(detail.field, detail.userMessage || detail.message);
+  }
+
+  return Object.fromEntries(errorMap);
+}
+
+export function extractServerDetail(details: unknown): string | null {
+  const candidate = getProblemDetails(details);
+  if (!candidate) return null;
+
+  if (candidate.errorDetails && candidate.errorDetails.length > 0) {
+    const lines = candidate.errorDetails.flatMap((detail) => {
+      const prefix = detail.fieldLabel ?? detail.field;
+      const primary = detail.userMessage || detail.message;
+      const line = prefix ? `${prefix}: ${primary}` : primary;
+      return detail.suggestedAction ? [line, `対応: ${detail.suggestedAction}`] : [line];
+    });
+
+    if (candidate.traceId) {
+      lines.push(`Trace ID: ${candidate.traceId}`);
+    }
+
+    if (lines.length > 0) {
+      return lines.join('\n');
+    }
+  }
+
+  if (candidate.detail) return candidate.detail;
+  const validationErrors = (candidate as ValidationProblemDetails).errors;
+  if (validationErrors) {
+    const lines = Object.entries(validationErrors)
+      .flatMap(([key, values]) => values.map((value) => `${key}: ${value}`));
+    if (lines.length > 0) return lines.join('\n');
+  }
+  if (candidate.title) return candidate.title;
+  return null;
+}

--- a/lib/game-management/maintenance.test.ts
+++ b/lib/game-management/maintenance.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildMaintenanceSummaryText,
+  getMaintenanceHealthStatusLabel,
+  supportsMaintenance,
+} from './maintenance';
+
+describe('game-management maintenance helpers', () => {
+  it('detects maintenance-capable resources', () => {
+    expect(supportsMaintenance('game-consoles')).toBe(true);
+    expect(supportsMaintenance('game-softwares')).toBe(true);
+    expect(supportsMaintenance('memory-cards')).toBe(true);
+    expect(supportsMaintenance('accounts')).toBe(false);
+  });
+
+  it('formats maintenance summaries with status and overdue information', () => {
+    expect(buildMaintenanceSummaryText({
+      hasRecord: true,
+      intervalDays: 365,
+      lastMaintenanceDate: '2026-05-01',
+      nextMaintenanceDate: '2026-06-01',
+      isOverdue: true,
+      latestHealthStatus: 2,
+    })).toBe('保守: 起動不調 / 最終: 2026/05/01 / 次回: 2026/06/01 / 期限超過');
+  });
+
+  it('shows a clear message when no maintenance exists', () => {
+    expect(buildMaintenanceSummaryText({
+      hasRecord: false,
+      intervalDays: 365,
+      lastMaintenanceDate: null,
+      nextMaintenanceDate: null,
+      isOverdue: false,
+      latestHealthStatus: 0,
+    })).toBe('保守: 記録なし');
+    expect(getMaintenanceHealthStatusLabel(0)).toBe('未確認');
+  });
+});

--- a/lib/game-management/maintenance.ts
+++ b/lib/game-management/maintenance.ts
@@ -1,0 +1,53 @@
+import type {
+  MaintenanceHealthFilter,
+  MaintenanceHealthStatus,
+  MaintenanceSummaryDto,
+  ResourceKey,
+} from './types';
+
+export const MAINTENANCE_FILTER_OPTIONS: Array<{ value: MaintenanceHealthFilter; label: string }> = [
+  { value: 'All', label: 'すべて表示' },
+  { value: 'ExcludeUnhealthy', label: '起動不調を除外' },
+  { value: 'OnlyUnhealthy', label: '起動不調のみ' },
+];
+
+export function supportsMaintenance(resourceKey: ResourceKey): resourceKey is 'game-consoles' | 'game-softwares' | 'memory-cards' {
+  return resourceKey === 'game-consoles' || resourceKey === 'game-softwares' || resourceKey === 'memory-cards';
+}
+
+export function getMaintenanceHealthStatusLabel(status: MaintenanceHealthStatus): string {
+  switch (status) {
+    case 1:
+      return '正常';
+    case 2:
+      return '起動不調';
+    default:
+      return '未確認';
+  }
+}
+
+export function formatMaintenanceDate(value: string | null): string {
+  if (!value) {
+    return '未記録';
+  }
+
+  return value.slice(0, 10).replace(/-/g, '/');
+}
+
+export function buildMaintenanceSummaryText(summary: MaintenanceSummaryDto | null | undefined): string {
+  if (!summary || !summary.hasRecord) {
+    return '保守: 記録なし';
+  }
+
+  const parts = [
+    `保守: ${getMaintenanceHealthStatusLabel(summary.latestHealthStatus)}`,
+    `最終: ${formatMaintenanceDate(summary.lastMaintenanceDate)}`,
+    `次回: ${formatMaintenanceDate(summary.nextMaintenanceDate)}`,
+  ];
+
+  if (summary.isOverdue) {
+    parts.push('期限超過');
+  }
+
+  return parts.join(' / ');
+}

--- a/lib/game-management/save-data-search.test.ts
+++ b/lib/game-management/save-data-search.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it } from 'vitest';
+
+import { evaluateSaveDataSearch, getSaveDataVariant, matchesSaveDataSearchGroup } from './save-data-search';
+import type { ManagementLookups, SaveDataSchemaDto } from './types';
+
+const schema: SaveDataSchemaDto = {
+  gameSoftwareMasterId: 100,
+  contentGroupId: 10,
+  fields: [
+    {
+      fieldKey: 'trainer-name',
+      label: '主人公名',
+      description: null,
+      fieldType: 0,
+      displayOrder: 1,
+      isRequired: false,
+      isDisabled: false,
+      options: [],
+    },
+    {
+      fieldKey: 'is-cleared',
+      label: 'クリア済み',
+      description: null,
+      fieldType: 4,
+      displayOrder: 2,
+      isRequired: false,
+      isDisabled: false,
+      options: [],
+    },
+    {
+      fieldKey: 'badge-count',
+      label: 'バッジ数',
+      description: null,
+      fieldType: 2,
+      displayOrder: 3,
+      isRequired: false,
+      isDisabled: false,
+      options: [],
+    },
+    {
+      fieldKey: 'play-time',
+      label: 'プレイ時間',
+      description: null,
+      fieldType: 3,
+      displayOrder: 4,
+      isRequired: false,
+      isDisabled: false,
+      options: [],
+    },
+    {
+      fieldKey: 'last-played-on',
+      label: '最終プレイ日',
+      description: null,
+      fieldType: 5,
+      displayOrder: 5,
+      isRequired: false,
+      isDisabled: false,
+      options: [],
+    },
+    {
+      fieldKey: 'starter',
+      label: '相棒',
+      description: null,
+      fieldType: 6,
+      displayOrder: 6,
+      isRequired: false,
+      isDisabled: false,
+      options: [
+        {
+          optionKey: 'pikachu',
+          label: 'ピカチュウ',
+          description: null,
+          displayOrder: 1,
+        },
+        {
+          optionKey: 'eevee',
+          label: 'イーブイ',
+          description: null,
+          displayOrder: 2,
+        },
+      ],
+    },
+  ],
+};
+
+const lookups: ManagementLookups = {
+  accountTypeMasters: [],
+  accounts: [],
+  gameConsoleCategories: [],
+  gameConsoleCategoryCompatibilities: [],
+  gameConsoleEditionMasters: [],
+  gameConsoleMasters: [],
+  gameConsoles: [],
+  gameSoftwareContentGroups: [],
+  gameSoftwareMasters: [
+    { id: 100, name: 'ソフトA', abbreviation: 'A', gameConsoleCategoryId: 1, contentGroupId: 10, displayOrder: 1, isDeleted: false },
+    { id: 200, name: 'ソフトB', abbreviation: 'B', gameConsoleCategoryId: 1, contentGroupId: 10, displayOrder: 2, isDeleted: false },
+  ],
+  gameSoftwares: [
+    {
+      id: 10,
+      gameSoftwareMasterId: 100,
+      variant: 0,
+      accountId: null,
+      installedGameConsoleId: null,
+      ownerGoogleUserId: 'owner',
+      displayOrder: 1,
+      label: 'A package',
+      memo: null,
+      isDeleted: false,
+      maintenance: {
+        hasRecord: false,
+        intervalDays: 365,
+        lastMaintenanceDate: null,
+        nextMaintenanceDate: null,
+        isOverdue: false,
+        latestHealthStatus: 0,
+      },
+    },
+    {
+      id: 20,
+      gameSoftwareMasterId: 200,
+      variant: 1,
+      accountId: null,
+      installedGameConsoleId: null,
+      ownerGoogleUserId: 'owner',
+      displayOrder: 2,
+      label: 'B download',
+      memo: null,
+      isDeleted: false,
+      maintenance: {
+        hasRecord: false,
+        intervalDays: 365,
+        lastMaintenanceDate: null,
+        nextMaintenanceDate: null,
+        isOverdue: false,
+        latestHealthStatus: 0,
+      },
+    },
+  ],
+  memoryCardEditionMasters: [],
+  memoryCards: [],
+  saveDatas: [
+    {
+      id: 1,
+      ownerGoogleUserId: 'owner',
+      displayOrder: 1,
+      memo: 'メイン',
+      replacedBySaveDataId: null,
+      saveStorageType: 0,
+      gameSoftwareMasterId: 100,
+      gameSoftwareId: 10,
+      gameConsoleId: null,
+      accountId: null,
+      memoryCardId: null,
+      storyProgressDefinitionId: 1000,
+      extendedFields: [
+        {
+          fieldKey: 'trainer-name',
+          label: '主人公名',
+          fieldType: 0,
+          isRequired: false,
+          displayOrder: 1,
+          stringValue: 'ピカ',
+          intValue: null,
+          decimalValue: null,
+          boolValue: null,
+          dateValue: null,
+          selectedOptionKey: null,
+        },
+        {
+          fieldKey: 'is-cleared',
+          label: 'クリア済み',
+          fieldType: 4,
+          isRequired: false,
+          displayOrder: 2,
+          stringValue: null,
+          intValue: null,
+          decimalValue: null,
+          boolValue: true,
+          dateValue: null,
+          selectedOptionKey: null,
+        },
+        {
+          fieldKey: 'badge-count',
+          label: 'バッジ数',
+          fieldType: 2,
+          isRequired: false,
+          displayOrder: 3,
+          stringValue: null,
+          intValue: 1,
+          decimalValue: null,
+          boolValue: null,
+          dateValue: null,
+          selectedOptionKey: null,
+        },
+        {
+          fieldKey: 'play-time',
+          label: 'プレイ時間',
+          fieldType: 3,
+          isRequired: false,
+          displayOrder: 4,
+          stringValue: null,
+          intValue: null,
+          decimalValue: 1,
+          boolValue: null,
+          dateValue: null,
+          selectedOptionKey: null,
+        },
+        {
+          fieldKey: 'last-played-on',
+          label: '最終プレイ日',
+          fieldType: 5,
+          isRequired: false,
+          displayOrder: 5,
+          stringValue: null,
+          intValue: null,
+          decimalValue: null,
+          boolValue: null,
+          dateValue: '2024-12-31',
+          selectedOptionKey: null,
+        },
+        {
+          fieldKey: 'starter',
+          label: '相棒',
+          fieldType: 6,
+          isRequired: false,
+          displayOrder: 6,
+          stringValue: null,
+          intValue: null,
+          decimalValue: null,
+          boolValue: null,
+          dateValue: null,
+          selectedOptionKey: 'pikachu',
+        },
+      ],
+      isDeleted: false,
+      deleteReason: null,
+    },
+    {
+      id: 2,
+      ownerGoogleUserId: 'owner',
+      displayOrder: 2,
+      memo: null,
+      replacedBySaveDataId: null,
+      saveStorageType: 0,
+      gameSoftwareMasterId: 200,
+      gameSoftwareId: 20,
+      gameConsoleId: null,
+      accountId: null,
+      memoryCardId: null,
+      storyProgressDefinitionId: 2000,
+      extendedFields: [],
+      isDeleted: false,
+      deleteReason: null,
+    },
+  ],
+};
+
+describe('save-data search helpers', () => {
+  it('reads variant from linked game software', () => {
+    expect(getSaveDataVariant(lookups.saveDatas[0], lookups)).toBe(0);
+    expect(getSaveDataVariant({ ...lookups.saveDatas[0], gameSoftwareId: null }, lookups)).toBeNull();
+  });
+
+  it('matches text contains and boolean exact conditions inside a group', () => {
+    expect(matchesSaveDataSearchGroup(
+      lookups.saveDatas[0],
+      {
+        gameSoftwareMasterId: 100,
+        storyProgressDefinitionId: 1000,
+        fieldConditions: [
+          { fieldKey: 'trainer-name', value: 'ピ' },
+          { fieldKey: 'is-cleared', value: 'true' },
+        ],
+      },
+      schema,
+    )).toBe(true);
+  });
+
+  it('matches numeric equality by numeric value and keeps date/option exact comparisons', () => {
+    expect(matchesSaveDataSearchGroup(
+      lookups.saveDatas[0],
+      {
+        gameSoftwareMasterId: 100,
+        storyProgressDefinitionId: 1000,
+        fieldConditions: [
+          { fieldKey: 'badge-count', value: '1.0' },
+          { fieldKey: 'play-time', value: '1.00' },
+          { fieldKey: 'last-played-on', value: '2024-12-31' },
+          { fieldKey: 'starter', value: 'pikachu' },
+        ],
+      },
+      schema,
+    )).toBe(true);
+
+    expect(matchesSaveDataSearchGroup(
+      lookups.saveDatas[0],
+      {
+        gameSoftwareMasterId: 100,
+        storyProgressDefinitionId: 1000,
+        fieldConditions: [
+          { fieldKey: 'badge-count', value: '1.5' },
+        ],
+      },
+      schema,
+    )).toBe(false);
+  });
+
+  it('applies variant as a common AND filter and groups as OR', () => {
+    const matches = evaluateSaveDataSearch(lookups, { 100: schema }, {
+      variant: 0,
+      groups: [
+        {
+          gameSoftwareMasterId: 100,
+          storyProgressDefinitionId: 1000,
+          fieldConditions: [{ fieldKey: 'trainer-name', value: 'ピカ' }],
+        },
+        {
+          gameSoftwareMasterId: 200,
+          storyProgressDefinitionId: 2000,
+          fieldConditions: [],
+        },
+      ],
+    });
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.saveData.id).toBe(1);
+    expect(matches[0]?.matchedGroupIndexes).toEqual([0]);
+  });
+});

--- a/lib/game-management/save-data-search.ts
+++ b/lib/game-management/save-data-search.ts
@@ -1,0 +1,188 @@
+import { mergeSchemaWithSaveData } from './save-data-fields';
+import type {
+  GameSoftwareVariant,
+  ManagementLookups,
+  SaveDataDto,
+  SaveDataFieldType,
+  SaveDataSchemaDto,
+} from './types';
+
+export const GAME_SOFTWARE_VARIANT_OPTIONS = [
+  { value: '', label: 'すべて' },
+  { value: '0', label: 'パッケージ版' },
+  { value: '1', label: 'ダウンロード版' },
+] as const;
+
+export type SaveDataSearchFieldCondition = {
+  fieldKey: string;
+  value: string;
+};
+
+export type SaveDataSearchGroup = {
+  gameSoftwareMasterId: number;
+  storyProgressDefinitionId?: number | null;
+  fieldConditions: SaveDataSearchFieldCondition[];
+};
+
+export type SaveDataSearchCriteria = {
+  variant?: GameSoftwareVariant | null;
+  groups: SaveDataSearchGroup[];
+};
+
+export type SaveDataSearchMatch = {
+  saveData: SaveDataDto;
+  matchedGroupIndexes: number[];
+};
+
+function normalizeText(value: string): string {
+  return value.trim().toLocaleLowerCase('ja');
+}
+
+function parseNumericValue(value: string | null): number | null {
+  if (value == null || value.trim().length === 0) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function matchesFieldConditionByType(
+  fieldType: SaveDataFieldType,
+  actualValue: string | null,
+  expectedValue: string,
+): boolean {
+  const normalizedExpected = expectedValue.trim();
+
+  switch (fieldType) {
+    case 0:
+    case 1:
+      return normalizeText(actualValue ?? '').includes(normalizeText(normalizedExpected));
+    case 2: {
+      const actualNumber = parseNumericValue(actualValue);
+      const expectedNumber = parseNumericValue(normalizedExpected);
+      return actualNumber != null
+        && expectedNumber != null
+        && Number.isInteger(actualNumber)
+        && Number.isInteger(expectedNumber)
+        && actualNumber === expectedNumber;
+    }
+    case 3: {
+      const actualNumber = parseNumericValue(actualValue);
+      const expectedNumber = parseNumericValue(normalizedExpected);
+      return actualNumber != null && expectedNumber != null && actualNumber === expectedNumber;
+    }
+    case 4:
+      return (actualValue ?? 'false') === normalizedExpected;
+    default:
+      return (actualValue ?? '') === normalizedExpected;
+  }
+}
+
+export function getSaveDataVariant(
+  saveData: SaveDataDto,
+  lookups: Pick<ManagementLookups, 'gameSoftwares'>,
+): GameSoftwareVariant | null {
+  if (!saveData.gameSoftwareId) {
+    return null;
+  }
+
+  return lookups.gameSoftwares.find((item) => item.id === saveData.gameSoftwareId)?.variant ?? null;
+}
+
+export function matchesSaveDataSearchGroup(
+  saveData: SaveDataDto,
+  group: SaveDataSearchGroup,
+  schema: SaveDataSchemaDto | null | undefined,
+): boolean {
+  if (saveData.gameSoftwareMasterId !== group.gameSoftwareMasterId) {
+    return false;
+  }
+
+  if (group.storyProgressDefinitionId != null && saveData.storyProgressDefinitionId !== group.storyProgressDefinitionId) {
+    return false;
+  }
+
+  if (group.fieldConditions.length === 0) {
+    return true;
+  }
+
+  if (!schema) {
+    return false;
+  }
+
+  const mergedFields = mergeSchemaWithSaveData(schema, saveData);
+
+  return group.fieldConditions.every((condition) => {
+    const field = mergedFields.find((item) => item.fieldKey === condition.fieldKey && !item.isDisabled);
+    if (!field) {
+      return false;
+    }
+
+    let actualValue: string | null;
+    switch (field.fieldType) {
+      case 0:
+      case 1:
+        actualValue = field.stringValue;
+        break;
+      case 2:
+        actualValue = field.intValue == null ? null : String(field.intValue);
+        break;
+      case 3:
+        actualValue = field.decimalValue == null ? null : String(field.decimalValue);
+        break;
+      case 4:
+        actualValue = String(field.boolValue ?? false);
+        break;
+      case 5:
+        actualValue = field.dateValue;
+        break;
+      case 6:
+        actualValue = field.selectedOptionKey;
+        break;
+      default:
+        actualValue = null;
+        break;
+    }
+
+    return matchesFieldConditionByType(field.fieldType, actualValue, condition.value);
+  });
+}
+
+export function evaluateSaveDataSearch(
+  lookups: ManagementLookups,
+  schemaMap: Record<number, SaveDataSchemaDto>,
+  criteria: SaveDataSearchCriteria,
+): SaveDataSearchMatch[] {
+  if (criteria.groups.length === 0) {
+    return [];
+  }
+
+  return lookups.saveDatas
+    .map((saveData) => {
+      if (criteria.variant != null && getSaveDataVariant(saveData, lookups) !== criteria.variant) {
+        return null;
+      }
+
+      const matchedGroupIndexes = criteria.groups.reduce<number[]>((result, group, index) => {
+        if (matchesSaveDataSearchGroup(saveData, group, schemaMap[group.gameSoftwareMasterId])) {
+          result.push(index);
+        }
+        return result;
+      }, []);
+
+      if (matchedGroupIndexes.length === 0) {
+        return null;
+      }
+
+      return {
+        saveData,
+        matchedGroupIndexes,
+      } satisfies SaveDataSearchMatch;
+    })
+    .filter((item): item is SaveDataSearchMatch => item !== null)
+    .sort((left, right) => (
+      left.saveData.displayOrder - right.saveData.displayOrder
+      || left.saveData.id - right.saveData.id
+    ));
+}

--- a/lib/game-management/trial/resources.ts
+++ b/lib/game-management/trial/resources.ts
@@ -11,6 +11,7 @@ import type {
   CreateSaveDataRequest,
   GameConsoleDto,
   GameSoftwareDto,
+  MaintenanceSummaryDto,
   ManagementLookups,
   MasterLookups,
   MemoryCardDto,
@@ -37,6 +38,17 @@ function resolveDisplayOrder(displayOrder: number | null | undefined, fallback: 
   return typeof displayOrder === 'number' && Number.isInteger(displayOrder) && displayOrder > 0
     ? displayOrder
     : fallback;
+}
+
+function createTrialMaintenanceSummary(): MaintenanceSummaryDto {
+  return {
+    hasRecord: false,
+    intervalDays: 365,
+    lastMaintenanceDate: null,
+    nextMaintenanceDate: null,
+    isOverdue: false,
+    latestHealthStatus: 0,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -95,7 +107,10 @@ export function trialDeleteAccount(id: number): void {
 // ---------------------------------------------------------------------------
 
 export function trialListGameConsoles(): GameConsoleDto[] {
-  return readDisplayOrderedList<GameConsoleDto>('game-consoles');
+  return readDisplayOrderedList<GameConsoleDto>('game-consoles').map((item) => ({
+    ...item,
+    maintenance: item.maintenance ?? createTrialMaintenanceSummary(),
+  }));
 }
 
 export function trialGetGameConsole(id: number): GameConsoleDto | undefined {
@@ -114,6 +129,7 @@ export function trialCreateGameConsole(payload: CreateGameConsoleRequest): numbe
     label: payload.label,
     memo: payload.memo,
     isDeleted: false,
+    maintenance: createTrialMaintenanceSummary(),
   });
   writeList('game-consoles', items);
   return newId;
@@ -149,7 +165,10 @@ export function trialDeleteGameConsole(id: number): void {
 // ---------------------------------------------------------------------------
 
 export function trialListGameSoftwares(): GameSoftwareDto[] {
-  return readDisplayOrderedList<GameSoftwareDto>('game-softwares');
+  return readDisplayOrderedList<GameSoftwareDto>('game-softwares').map((item) => ({
+    ...item,
+    maintenance: item.maintenance ?? createTrialMaintenanceSummary(),
+  }));
 }
 
 export function trialGetGameSoftware(id: number): GameSoftwareDto | undefined {
@@ -170,6 +189,7 @@ export function trialCreateGameSoftware(payload: CreateGameSoftwareRequest): num
     label: payload.label,
     memo: payload.memo,
     isDeleted: false,
+    maintenance: createTrialMaintenanceSummary(),
   });
   writeList('game-softwares', items);
   return newId;
@@ -204,7 +224,10 @@ export function trialDeleteGameSoftware(id: number): void {
 // ---------------------------------------------------------------------------
 
 export function trialListMemoryCards(): MemoryCardDto[] {
-  return readDisplayOrderedList<MemoryCardDto>('memory-cards');
+  return readDisplayOrderedList<MemoryCardDto>('memory-cards').map((item) => ({
+    ...item,
+    maintenance: item.maintenance ?? createTrialMaintenanceSummary(),
+  }));
 }
 
 export function trialGetMemoryCard(id: number): MemoryCardDto | undefined {
@@ -222,6 +245,7 @@ export function trialCreateMemoryCard(payload: CreateMemoryCardRequest): number 
     label: payload.label,
     memo: payload.memo,
     isDeleted: false,
+    maintenance: createTrialMaintenanceSummary(),
   });
   writeList('memory-cards', items);
   return newId;

--- a/lib/game-management/types.ts
+++ b/lib/game-management/types.ts
@@ -6,16 +6,59 @@ export type GameSoftwareVariant = 0 | 1;
 
 export type MemoryCardBlockCount = 59 | 251 | 1019;
 
+export type MaintenanceHealthStatus = 0 | 1 | 2;
+
+export type MaintenanceHealthFilter = 'All' | 'ExcludeUnhealthy' | 'OnlyUnhealthy';
+
+export type ApiErrorDetail = {
+  code: string;
+  field?: string;
+  fieldLabel?: string;
+  message: string;
+  userMessage: string;
+  suggestedAction: string;
+};
+
 export type ProblemDetails = {
   type?: string;
   title?: string;
   status?: number;
   detail?: string;
   instance?: string;
+  traceId?: string;
+  errorDetails?: ApiErrorDetail[];
 };
 
 export type ValidationProblemDetails = ProblemDetails & {
   errors?: Record<string, string[]>;
+};
+
+export type CurrentUserDto = {
+  ownerGoogleUserId: string;
+  assignedRoles: string[];
+  effectiveRoles: string[];
+  isAdmin: boolean;
+  isBootstrapEligible: boolean;
+};
+
+export type UserRoleAssignmentDto = {
+  ownerGoogleUserId: string;
+  assignedRoles: string[];
+  effectiveRoles: string[];
+  isBootstrapEligible: boolean;
+};
+
+export type SetUserRolesRequest = {
+  assignedRoles: string[];
+};
+
+export type MaintenanceSummaryDto = {
+  hasRecord: boolean;
+  intervalDays: number;
+  lastMaintenanceDate: string | null;
+  nextMaintenanceDate: string | null;
+  isOverdue: boolean;
+  latestHealthStatus: MaintenanceHealthStatus;
 };
 
 // ---------------------------------------------------------------------------
@@ -188,6 +231,7 @@ export type GameConsoleDto = {
   label: string | null;
   memo: string | null;
   isDeleted: boolean;
+  maintenance: MaintenanceSummaryDto;
 };
 
 export type CreateGameConsoleRequest = {
@@ -208,6 +252,30 @@ export type GameConsoleCountByMasterDto = {
   gameConsoleMasterId: number;
   gameConsoleMasterName: string | null;
   count: number;
+};
+
+export type GameConsoleMaintenanceDto = {
+  id: number;
+  gameConsoleId: number;
+  maintenanceDate: string;
+  isPowerOnPerformed: boolean;
+  isStartupConfirmed: boolean;
+  memo: string | null;
+  isDeleted: boolean;
+};
+
+export type CreateGameConsoleMaintenanceRequest = {
+  maintenanceDate: string;
+  isPowerOnPerformed: boolean;
+  isStartupConfirmed: boolean;
+  memo: string | null;
+};
+
+export type UpdateGameConsoleMaintenanceRequest = {
+  maintenanceDate: string;
+  isPowerOnPerformed: boolean;
+  isStartupConfirmed: boolean;
+  memo: string | null;
 };
 
 // ---------------------------------------------------------------------------
@@ -274,6 +342,7 @@ export type GameSoftwareDto = {
   label: string | null;
   memo: string | null;
   isDeleted: boolean;
+  maintenance: MaintenanceSummaryDto;
 };
 
 export type CreateGameSoftwareRequest = {
@@ -298,6 +367,30 @@ export type GameSoftwareCountByMasterDto = {
   gameSoftwareMasterId: number;
   gameSoftwareMasterName: string | null;
   count: number;
+};
+
+export type GameSoftwareMaintenanceDto = {
+  id: number;
+  gameSoftwareId: number;
+  maintenanceDate: string;
+  isPowerOnPerformed: boolean;
+  isStartupConfirmed: boolean;
+  memo: string | null;
+  isDeleted: boolean;
+};
+
+export type CreateGameSoftwareMaintenanceRequest = {
+  maintenanceDate: string;
+  isPowerOnPerformed: boolean;
+  isStartupConfirmed: boolean;
+  memo: string | null;
+};
+
+export type UpdateGameSoftwareMaintenanceRequest = {
+  maintenanceDate: string;
+  isPowerOnPerformed: boolean;
+  isStartupConfirmed: boolean;
+  memo: string | null;
 };
 
 // ---------------------------------------------------------------------------
@@ -335,6 +428,7 @@ export type MemoryCardDto = {
   label: string | null;
   memo: string | null;
   isDeleted: boolean;
+  maintenance: MaintenanceSummaryDto;
 };
 
 export type CreateMemoryCardRequest = {
@@ -347,6 +441,36 @@ export type CreateMemoryCardRequest = {
 export type UpdateMemoryCardRequest = {
   memoryCardEditionMasterId: number;
   label: string | null;
+  memo: string | null;
+};
+
+export type MemoryCardCountByEditionDto = {
+  memoryCardEditionMasterId: number;
+  memoryCardEditionName: string | null;
+  count: number;
+};
+
+export type MemoryCardMaintenanceDto = {
+  id: number;
+  memoryCardId: number;
+  maintenanceDate: string;
+  isPowerOnPerformed: boolean;
+  isStartupConfirmed: boolean;
+  memo: string | null;
+  isDeleted: boolean;
+};
+
+export type CreateMemoryCardMaintenanceRequest = {
+  maintenanceDate: string;
+  isPowerOnPerformed: boolean;
+  isStartupConfirmed: boolean;
+  memo: string | null;
+};
+
+export type UpdateMemoryCardMaintenanceRequest = {
+  maintenanceDate: string;
+  isPowerOnPerformed: boolean;
+  isStartupConfirmed: boolean;
   memo: string | null;
 };
 


### PR DESCRIPTION
﻿## 概要
- main 向けに取り込んだ Issue #94 の実装を develop に反映します
- /game-library/maintenance と /game-library/save-data-search を追加します
- 保守履歴の親子ダイアログ UX と横断セーブデータ検索を含みます

## 変更内容
- Game Library ダッシュボードに新規導線を追加
- 横断保守ページと横断セーブデータ検索ページを追加
- maintenance / ProblemDetails / search helper のテストと関連ドキュメントを追加

## 関連
- Refs #94
- Mirrors #95 onto develop

## 確認事項
- [x] 
pm run lint
- [x] 
px vitest run --project unit
- [x] 
pm run build

<!-- lifecycle-state
feature: "一覧UI統一・保守履歴・横断セーブデータ検索"
entry_mode: "new"
issue: 94
pr: 96
branch: "feature/94-list-ui-maintenance-search"
plan_comment_url: "https://github.com/p-o-ke-nae/pokenae.Web/issues/94#issuecomment-4378131707"
phase: 3
step: "3.11"
status: "WAITING_HUMAN"
last_agent: "Orchestrator"
last_decision: "READY_FOR_REVIEW"
counters:
  spec_review: 2
  design_review: 2
  build_fail: 0
  code_review: 2
  completion_cycle: 1
  e2e_retry: 0
  doc_update: 1
updated_at: "2026-05-05T21:41:20Z"
-->