### PR TITLE
feat(pokemon-damage-calculator): add admin maintenance UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
 | 認証 | Google OAuth2 / NextAuth |
 | API 接続 | `createFrontendApiClient` と `/api/services/{service}/{...path}` proxy |
 | 開発前提 | Docker Compose ベース |
-| 実装済み機能 | ポケモンダメージ計算 (`/pokemon-damage-calculator`) |
+| 実装済み機能 | ポケモンダメージ計算 (`/pokemon-damage-calculator`) / 管理 UI (`/pokemon-damage-calculator/admin`) |
 
 ## Documentation
 
 - **[環境モードの設定と区別方法](./docs/ENVIRONMENT_SETUP.md)** - 環境変数、シークレット、追加 API サービス設定
 - **[API Routing Guide](./docs/API_ROUTING.md)** - API ルーティング基盤と proxy 運用方針
-- **[Pokemon Damage Calculator API 契約差分メモ](./docs/API_CONTRACT_DIFFS_POKEMON_DAMAGE_CALCULATOR_API.md)** - Issue #97 の実装反映済みメモ
+- **[Pokemon Damage Calculator API 契約差分メモ](./docs/API_CONTRACT_DIFFS_POKEMON_DAMAGE_CALCULATOR_API.md)** - ポケモンダメージ計算 / 管理 UI の実装反映メモ
 - **[Google Auth Setup Guide](./docs/GOOGLE_AUTH_SETUP.md)** - Google OAuth2認証の設定ガイド（英語）
 - **[Google OAuth2認証機能について](./docs/GOOGLE_AUTH_SETUP_JA.md)** - Google OAuth2認証の詳細解説（日本語）
 - **[Kernel Stack Overflow Investigation](./docs/KERNEL_STACK_OVERFLOW_INVESTIGATION.md)** - スタックオーバーフロー問題の調査と修正レポート

--- a/app/pokemon-damage-calculator/admin/layout.tsx
+++ b/app/pokemon-damage-calculator/admin/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react';
+
+export default function PokemonDamageCalculatorAdminLayout({ children }: { children: ReactNode }) {
+  return children;
+}
+

--- a/app/pokemon-damage-calculator/admin/page.tsx
+++ b/app/pokemon-damage-calculator/admin/page.tsx
@@ -1,0 +1,6 @@
+import { AdminHubPage } from '@/components/organisms/PokemonDamageCalculatorAdmin/AdminHubPage';
+
+export default function PokemonDamageCalculatorAdminIndexPage() {
+  return <AdminHubPage />;
+}
+

--- a/app/pokemon-damage-calculator/admin/rule-sets/[id]/page.tsx
+++ b/app/pokemon-damage-calculator/admin/rule-sets/[id]/page.tsx
@@ -1,0 +1,11 @@
+import { AdminRuleSetEditorPage } from '@/components/organisms/PokemonDamageCalculatorAdmin/AdminRuleSetEditorPage';
+
+export default async function PokemonDamageCalculatorAdminRuleSetDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return <AdminRuleSetEditorPage ruleSetId={id} />;
+}
+

--- a/app/pokemon-damage-calculator/admin/rule-sets/new/page.tsx
+++ b/app/pokemon-damage-calculator/admin/rule-sets/new/page.tsx
@@ -1,0 +1,6 @@
+import { AdminRuleSetEditorPage } from '@/components/organisms/PokemonDamageCalculatorAdmin/AdminRuleSetEditorPage';
+
+export default function PokemonDamageCalculatorAdminRuleSetCreatePage() {
+  return <AdminRuleSetEditorPage />;
+}
+

--- a/app/pokemon-damage-calculator/admin/rule-sets/page.tsx
+++ b/app/pokemon-damage-calculator/admin/rule-sets/page.tsx
@@ -1,0 +1,6 @@
+import { AdminRuleSetListPage } from '@/components/organisms/PokemonDamageCalculatorAdmin/AdminRuleSetListPage';
+
+export default function PokemonDamageCalculatorAdminRuleSetsPage() {
+  return <AdminRuleSetListPage />;
+}
+

--- a/app/pokemon-damage-calculator/admin/user-authorizations/[googleUserId]/page.tsx
+++ b/app/pokemon-damage-calculator/admin/user-authorizations/[googleUserId]/page.tsx
@@ -1,0 +1,11 @@
+import { AdminUserAuthorizationEditorPage } from '@/components/organisms/PokemonDamageCalculatorAdmin/AdminUserAuthorizationEditorPage';
+
+export default async function PokemonDamageCalculatorAdminUserAuthorizationDetailPage({
+  params,
+}: {
+  params: Promise<{ googleUserId: string }>;
+}) {
+  const { googleUserId } = await params;
+  return <AdminUserAuthorizationEditorPage googleUserId={googleUserId} />;
+}
+

--- a/app/pokemon-damage-calculator/admin/user-authorizations/new/page.tsx
+++ b/app/pokemon-damage-calculator/admin/user-authorizations/new/page.tsx
@@ -1,0 +1,6 @@
+import { AdminUserAuthorizationEditorPage } from '@/components/organisms/PokemonDamageCalculatorAdmin/AdminUserAuthorizationEditorPage';
+
+export default function PokemonDamageCalculatorAdminUserAuthorizationCreatePage() {
+  return <AdminUserAuthorizationEditorPage />;
+}
+

--- a/app/pokemon-damage-calculator/admin/user-authorizations/page.tsx
+++ b/app/pokemon-damage-calculator/admin/user-authorizations/page.tsx
@@ -1,0 +1,6 @@
+import { AdminUserAuthorizationListPage } from '@/components/organisms/PokemonDamageCalculatorAdmin/AdminUserAuthorizationListPage';
+
+export default function PokemonDamageCalculatorAdminUserAuthorizationsPage() {
+  return <AdminUserAuthorizationListPage />;
+}
+

--- a/components/organisms/PokemonDamageCalculatorAdmin/AdminHubPage.tsx
+++ b/components/organisms/PokemonDamageCalculatorAdmin/AdminHubPage.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { useEffect, useState } from 'react';
+import CustomButton from '@/components/atoms/CustomButton';
+import { AdminPageShell, AdminStateMessage, AdminSectionCard } from './shared';
+import { getAdminApiErrorMessage, isAdminApiUnauthorized } from '@/lib/pokemon-damage-calculator/admin/api';
+import { canManageRuleSets, canManageUserAuthorizations, probeAdminCapability } from '@/lib/pokemon-damage-calculator/admin/capability';
+import { getAdminRuleSetsPath, getAdminUserAuthorizationsPath } from '@/lib/pokemon-damage-calculator/admin/routes';
+import type { AdminCapability } from '@/lib/pokemon-damage-calculator/admin/constants';
+
+export function AdminHubPage() {
+  const router = useRouter();
+  const { status } = useSession();
+  const [capability, setCapability] = useState<AdminCapability | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<unknown>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      if (status === 'loading') {
+        return;
+      }
+
+      try {
+        setLoading(true);
+        setError(null);
+        const nextCapability = await probeAdminCapability(status === 'authenticated');
+        if (!cancelled) {
+          setCapability(nextCapability);
+        }
+      } catch (nextError) {
+        if (!cancelled) {
+          setError(nextError);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [status]);
+
+  return (
+    <AdminPageShell
+      title="ポケモンダメージ計算 管理トップ"
+      description="RuleSet と UserAuthorization の管理画面です。利用可能な機能だけを表示します。"
+    >
+      {loading ? <AdminStateMessage title="管理権限を確認しています..." /> : null}
+      {error && isAdminApiUnauthorized(error) ? (
+        <AdminStateMessage
+          title="再ログインしてください。"
+          detail="セッションの有効期限が切れています。ログインし直してください。"
+          signInCallbackUrl="/pokemon-damage-calculator/admin"
+        />
+      ) : null}
+      {error && !isAdminApiUnauthorized(error) ? (
+        <AdminStateMessage
+          tone="error"
+          title="管理トップの読み込みに失敗しました。"
+          detail={getAdminApiErrorMessage(error, '管理権限の確認に失敗しました。')}
+        />
+      ) : null}
+      {!loading && !error && capability === 'anonymous' ? (
+        <AdminStateMessage
+          title="ログインしてください。"
+          detail="管理画面を利用するには Google ログインが必要です。"
+          signInCallbackUrl="/pokemon-damage-calculator/admin"
+        />
+      ) : null}
+      {!loading && !error && capability === 'member' ? (
+        <AdminStateMessage
+          tone="warning"
+          title="このアカウントには管理権限がありません。"
+          detail="管理者またはマスタ編集権限のあるアカウントでログインしてください。"
+        />
+      ) : null}
+
+      {!loading && !error && capability && capability !== 'anonymous' && capability !== 'member' ? (
+        <div className="grid gap-6 md:grid-cols-2">
+          <AdminSectionCard
+          title="RuleSet 管理"
+          description="RuleSet の一覧、作成、更新、削除を行います。"
+            actions={(
+              <CustomButton variant="accent" disabled={!canManageRuleSets(capability)} onClick={() => router.push(getAdminRuleSetsPath())}>
+                開く
+              </CustomButton>
+            )}
+          >
+            <p className="text-sm text-zinc-600 dark:text-zinc-300">
+              {canManageRuleSets(capability) ? 'MasterEditor 以上で利用できます。' : '利用できません。'}
+            </p>
+          </AdminSectionCard>
+
+          <AdminSectionCard
+          title="UserAuthorization 管理"
+          description="Google ユーザーごとの role と permissions を管理します。"
+            actions={(
+              <CustomButton
+                variant="accent"
+                disabled={!canManageUserAuthorizations(capability)}
+                onClick={() => router.push(getAdminUserAuthorizationsPath())}
+              >
+                開く
+              </CustomButton>
+            )}
+          >
+            <p className="text-sm text-zinc-600 dark:text-zinc-300">
+              {canManageUserAuthorizations(capability) ? 'Administrator で利用できます。' : '利用できません。'}
+            </p>
+          </AdminSectionCard>
+        </div>
+      ) : null}
+    </AdminPageShell>
+  );
+}
+

--- a/components/organisms/PokemonDamageCalculatorAdmin/AdminRuleSetEditorPage.tsx
+++ b/components/organisms/PokemonDamageCalculatorAdmin/AdminRuleSetEditorPage.tsx
@@ -1,0 +1,381 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import CustomButton from '@/components/atoms/CustomButton';
+import {
+  FieldGroup,
+  SelectInput,
+  StatusMessage,
+  TextAreaInput,
+  TextInput,
+} from '@/components/organisms/PokemonDamageCalculator/shared';
+import { AdminPageShell, AdminStateMessage, AdminSectionCard } from './shared';
+import {
+  createAdminRuleSet,
+  deleteAdminRuleSet,
+  fetchAdminRuleSet,
+  getAdminApiErrorMessage,
+  getAdminProblemDetailsMessage,
+  isAdminApiForbidden,
+  isAdminApiNotFound,
+  isAdminApiUnauthorized,
+  updateAdminRuleSet,
+} from '@/lib/pokemon-damage-calculator/admin/api';
+import { canManageRuleSets, probeAdminCapability } from '@/lib/pokemon-damage-calculator/admin/capability';
+import { getAdminRuleSetPath, getAdminRuleSetsPath } from '@/lib/pokemon-damage-calculator/admin/routes';
+import {
+  ADMIN_RULE_SET_STATUSES,
+  type AdminCapability,
+} from '@/lib/pokemon-damage-calculator/admin/constants';
+import type {
+  AdminRuleSetDto,
+  AdminRuleSetFormState,
+  AdminRuleSetUpsertRequest,
+} from '@/lib/pokemon-damage-calculator/admin/types';
+import { validateAdminRuleSetForm } from '@/lib/pokemon-damage-calculator/admin/validation';
+
+function createEmptyForm(): AdminRuleSetFormState {
+  return {
+    slug: '',
+    generation: '1',
+    title: '',
+    version: '',
+    status: 'Draft',
+    summary: '',
+  };
+}
+
+function formFromRuleSet(ruleSet: AdminRuleSetDto): AdminRuleSetFormState {
+  return {
+    slug: ruleSet.slug,
+    generation: String(ruleSet.generation),
+    title: ruleSet.title,
+    version: ruleSet.version,
+    status: ruleSet.status,
+    summary: ruleSet.summary,
+  };
+}
+
+function toRequest(form: AdminRuleSetFormState): AdminRuleSetUpsertRequest {
+  return {
+    slug: form.slug.trim(),
+    generation: Number.parseInt(form.generation, 10),
+    title: form.title.trim(),
+    version: form.version.trim(),
+    status: form.status,
+    summary: form.summary.trim(),
+  };
+}
+
+export function AdminRuleSetEditorPage({ ruleSetId }: { ruleSetId?: string }) {
+  const router = useRouter();
+  const { status } = useSession();
+  const isNew = !ruleSetId;
+  const [capability, setCapability] = useState<AdminCapability | null>(null);
+  const [capabilityLoading, setCapabilityLoading] = useState(true);
+  const [recordLoading, setRecordLoading] = useState(false);
+  const [recordError, setRecordError] = useState<unknown>(null);
+  const [record, setRecord] = useState<AdminRuleSetDto | null>(null);
+  const [form, setForm] = useState<AdminRuleSetFormState>(createEmptyForm());
+  const [validationErrors, setValidationErrors] = useState<string[]>([]);
+  const [serverMessage, setServerMessage] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadCapability = async () => {
+      if (status === 'loading') {
+        return;
+      }
+
+      try {
+        setCapabilityLoading(true);
+        const nextCapability = await probeAdminCapability(status === 'authenticated');
+        if (!cancelled) {
+          setCapability(nextCapability);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setRecordError(error);
+        }
+      } finally {
+        if (!cancelled) {
+          setCapabilityLoading(false);
+        }
+      }
+    };
+
+    void loadCapability();
+    return () => {
+      cancelled = true;
+    };
+  }, [status]);
+
+  useEffect(() => {
+    if (isNew || !capability || !canManageRuleSets(capability)) {
+      return;
+    }
+
+    if (!ruleSetId) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        setRecordLoading(true);
+        setRecordError(null);
+        const nextRecord = await fetchAdminRuleSet(ruleSetId);
+        if (cancelled) {
+          return;
+        }
+
+        setRecord(nextRecord);
+        setForm(formFromRuleSet(nextRecord));
+      } catch (error) {
+        if (!cancelled) {
+          setRecordError(error);
+        }
+      } finally {
+        if (!cancelled) {
+          setRecordLoading(false);
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [capability, isNew, ruleSetId]);
+
+  const pageTitle = isNew ? 'RuleSet 新規作成' : 'RuleSet 詳細 / 更新';
+
+  const localizedError = useMemo(() => {
+    if (!recordError) {
+      return null;
+    }
+
+    if (isAdminApiUnauthorized(recordError)) {
+      return 'セッションの有効期限が切れています。ログインし直してください。';
+    }
+
+    if (isAdminApiForbidden(recordError)) {
+      return 'RuleSet 管理の権限がありません。';
+    }
+
+    if (isAdminApiNotFound(recordError)) {
+      return isNew ? null : getAdminProblemDetailsMessage((recordError as { details?: unknown }).details, '指定した RuleSet は見つかりません。');
+    }
+
+    return getAdminApiErrorMessage(recordError, 'RuleSet の読み込みに失敗しました。');
+  }, [isNew, recordError]);
+
+  const canEdit = capability ? canManageRuleSets(capability) : false;
+
+  const submit = useCallback(async () => {
+    const errors = validateAdminRuleSetForm(form);
+    setValidationErrors(errors);
+    setServerMessage(null);
+    if (errors.length > 0 || !canEdit) {
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      const request = toRequest(form);
+      const nextRecord = isNew
+        ? await createAdminRuleSet(request)
+        : await updateAdminRuleSet(ruleSetId as string, request);
+      setRecord(nextRecord);
+      setForm(formFromRuleSet(nextRecord));
+      setServerMessage('保存しました。');
+      setDeleteOpen(false);
+      if (isNew) {
+        router.push(getAdminRuleSetPath(nextRecord.id));
+      }
+    } catch (error) {
+      setServerMessage(getAdminProblemDetailsMessage((error as { details?: unknown }).details, getAdminApiErrorMessage(error, '保存に失敗しました。')));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [canEdit, form, isNew, router, ruleSetId]);
+
+  const handleDelete = useCallback(async () => {
+    if (!record || !ruleSetId) {
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      setServerMessage(null);
+      await deleteAdminRuleSet(ruleSetId);
+      router.push(getAdminRuleSetsPath());
+    } catch (error) {
+      setServerMessage(getAdminProblemDetailsMessage((error as { details?: unknown }).details, getAdminApiErrorMessage(error, '削除に失敗しました。')));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [record, router, ruleSetId]);
+
+  if (status === 'loading' || capabilityLoading) {
+    return (
+      <AdminPageShell title={pageTitle} description="管理用 RuleSet を作成・更新します。">
+        <AdminStateMessage title="アクセス権限を確認しています..." />
+      </AdminPageShell>
+    );
+  }
+
+  if (!capability) {
+    if (isAdminApiUnauthorized(recordError)) {
+      return (
+        <AdminPageShell title={pageTitle} description="管理用 RuleSet を作成・更新します。">
+          <AdminStateMessage
+            title="再ログインしてください。"
+            detail="セッションの有効期限が切れています。ログインし直してください。"
+            signInCallbackUrl={isNew ? getAdminRuleSetsPath() : getAdminRuleSetPath(ruleSetId ?? '')}
+          />
+        </AdminPageShell>
+      );
+    }
+
+    return (
+      <AdminPageShell title={pageTitle} description="管理用 RuleSet を作成・更新します。">
+        <AdminStateMessage
+          tone="error"
+          title="アクセス権限の確認に失敗しました。"
+          detail={localizedError ?? '権限情報を取得できませんでした。'}
+        />
+      </AdminPageShell>
+    );
+  }
+
+  if (status !== 'authenticated') {
+    return (
+      <AdminPageShell title={pageTitle} description="管理用 RuleSet を作成・更新します。">
+        <AdminStateMessage
+          title="ログインしてください。"
+          detail="RuleSet 管理を利用するには Google ログインが必要です。"
+          signInCallbackUrl={isNew ? getAdminRuleSetsPath() : getAdminRuleSetPath(ruleSetId ?? '')}
+        />
+      </AdminPageShell>
+    );
+  }
+
+  if (!canEdit) {
+    return (
+      <AdminPageShell title={pageTitle} description="管理用 RuleSet を作成・更新します。">
+        <AdminStateMessage
+          tone="warning"
+          title="RuleSet 管理の権限がありません。"
+          detail="MasterEditor 以上のアカウントでログインしてください。"
+        />
+      </AdminPageShell>
+    );
+  }
+
+  if (!isNew && isAdminApiNotFound(recordError)) {
+    return (
+      <AdminPageShell title={pageTitle} description="管理用 RuleSet を作成・更新します。">
+        <AdminStateMessage
+          tone="warning"
+          title="指定した RuleSet は見つかりません。"
+          detail="一覧に戻って別の RuleSet を選択してください。"
+          signInCallbackUrl={getAdminRuleSetsPath()}
+        />
+      </AdminPageShell>
+    );
+  }
+
+  return (
+    <AdminPageShell title={pageTitle} description="管理用 RuleSet を作成・更新します。">
+      <div className="flex flex-wrap gap-3">
+        <CustomButton variant="ghost" onClick={() => router.push(getAdminRuleSetsPath())}>
+          一覧へ戻る
+        </CustomButton>
+        {!isNew ? (
+          <CustomButton variant="ghost" onClick={() => setDeleteOpen((current) => !current)} disabled={submitting}>
+            {deleteOpen ? '削除を閉じる' : '削除'}
+          </CustomButton>
+        ) : null}
+      </div>
+
+      {recordLoading ? <AdminStateMessage title="RuleSet を読み込んでいます..." /> : null}
+      {serverMessage ? <AdminStateMessage tone="success" title={serverMessage} /> : null}
+      {localizedError ? <AdminStateMessage tone="error" title="読み込みに失敗しました。" detail={localizedError} /> : null}
+      {validationErrors.length > 0 ? (
+        <StatusMessage tone="error">
+          <ul className="list-disc pl-5">
+            {validationErrors.map((error) => <li key={error}>{error}</li>)}
+          </ul>
+        </StatusMessage>
+      ) : null}
+
+      <AdminSectionCard title="RuleSet フォーム" description="backend request DTO と 1 対 1 で対応します。">
+        <div className="grid gap-4 md:grid-cols-2">
+          <FieldGroup label="slug">
+            <TextInput value={form.slug} disabled={submitting} onChange={(event) => setForm((current) => ({ ...current, slug: event.target.value }))} />
+          </FieldGroup>
+          <FieldGroup label="generation">
+            <TextInput type="number" min={1} value={form.generation} disabled={submitting} onChange={(event) => setForm((current) => ({ ...current, generation: event.target.value }))} />
+          </FieldGroup>
+          <FieldGroup label="title">
+            <TextInput value={form.title} disabled={submitting} onChange={(event) => setForm((current) => ({ ...current, title: event.target.value }))} />
+          </FieldGroup>
+          <FieldGroup label="version">
+            <TextInput value={form.version} disabled={submitting} onChange={(event) => setForm((current) => ({ ...current, version: event.target.value }))} />
+          </FieldGroup>
+          <FieldGroup label="status">
+            <SelectInput value={form.status} disabled={submitting} onChange={(event) => setForm((current) => ({ ...current, status: event.target.value as AdminRuleSetFormState['status'] }))}>
+              {ADMIN_RULE_SET_STATUSES.map((statusOption) => (
+                <option key={statusOption} value={statusOption}>{statusOption}</option>
+              ))}
+            </SelectInput>
+          </FieldGroup>
+        </div>
+        <FieldGroup label="summary" hint="backend の summary にそのまま保存します。">
+          <TextAreaInput
+            rows={6}
+            value={form.summary}
+            disabled={submitting}
+            onChange={(event) => setForm((current) => ({ ...current, summary: event.target.value }))}
+          />
+        </FieldGroup>
+
+        <div className="mt-4 flex flex-wrap gap-3">
+          <CustomButton variant="accent" onClick={() => void submit()} disabled={submitting}>
+            {isNew ? '作成' : '更新'}
+          </CustomButton>
+        </div>
+      </AdminSectionCard>
+
+      {!isNew ? (
+        <AdminSectionCard title="削除確認" description="参照中の RuleSet は backend が 409 Conflict で拒否します。">
+          {record?.isReferencedByRuns ? (
+            <AdminStateMessage
+              tone="warning"
+              title="この RuleSet は Run から参照されています。"
+              detail="削除すると 409 Conflict になる可能性があります。参照を外してから削除してください。"
+            />
+          ) : null}
+          {deleteOpen ? (
+            <div className="flex flex-wrap gap-3">
+              <CustomButton variant="accent" onClick={() => void handleDelete()} disabled={submitting}>
+                削除を実行
+              </CustomButton>
+              <CustomButton variant="ghost" onClick={() => setDeleteOpen(false)} disabled={submitting}>
+                キャンセル
+              </CustomButton>
+            </div>
+          ) : null}
+        </AdminSectionCard>
+      ) : null}
+    </AdminPageShell>
+  );
+}
+

--- a/components/organisms/PokemonDamageCalculatorAdmin/AdminRuleSetListPage.tsx
+++ b/components/organisms/PokemonDamageCalculatorAdmin/AdminRuleSetListPage.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { useCallback, useEffect, useState } from 'react';
+import CustomButton from '@/components/atoms/CustomButton';
+import { AdminPageShell, AdminEmptyState, AdminStateMessage, AdminSectionCard } from './shared';
+import { fetchAdminRuleSets, getAdminApiErrorMessage, isAdminApiForbidden, isAdminApiUnauthorized } from '@/lib/pokemon-damage-calculator/admin/api';
+import { formatAdminRuleSetLabel, sortAdminRuleSets } from '@/lib/pokemon-damage-calculator/admin/mappers';
+import { getAdminRuleSetNewPath, getAdminRuleSetPath, getAdminRuleSetsPath, getAdminHomePath } from '@/lib/pokemon-damage-calculator/admin/routes';
+import type { AdminRuleSetDto } from '@/lib/pokemon-damage-calculator/admin/types';
+
+export function AdminRuleSetListPage() {
+  const router = useRouter();
+  const { status } = useSession();
+  const [ruleSets, setRuleSets] = useState<AdminRuleSetDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<unknown>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const nextRuleSets = await fetchAdminRuleSets();
+      setRuleSets(sortAdminRuleSets(nextRuleSets));
+    } catch (nextError) {
+      setError(nextError);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (status === 'loading') {
+      return;
+    }
+
+    if (status !== 'authenticated') {
+      setLoading(false);
+      return;
+    }
+
+    void load();
+  }, [load, status]);
+
+  const errorMessage = error ? getAdminApiErrorMessage(error, 'RuleSet 一覧の読み込みに失敗しました。') : null;
+
+  return (
+    <AdminPageShell
+      title="RuleSet 管理"
+      description="管理用 RuleSet の一覧、作成、更新、削除を行います。"
+    >
+      <div className="flex flex-wrap gap-3">
+        <CustomButton variant="ghost" onClick={() => void load()} disabled={loading || status !== 'authenticated'}>
+          再取得
+        </CustomButton>
+        <CustomButton variant="accent" disabled={status !== 'authenticated'} onClick={() => router.push(getAdminRuleSetNewPath())}>
+          新規作成
+        </CustomButton>
+        <CustomButton variant="ghost" onClick={() => router.push(getAdminHomePath())}>
+          管理トップへ戻る
+        </CustomButton>
+      </div>
+
+      {status === 'loading' || loading ? <AdminStateMessage title="RuleSet を読み込んでいます..." /> : null}
+      {status !== 'authenticated' ? (
+        <AdminStateMessage
+          title="ログインしてください。"
+          detail="RuleSet 管理を利用するには Google ログインが必要です。"
+          signInCallbackUrl={getAdminRuleSetsPath()}
+        />
+      ) : null}
+      {error && isAdminApiUnauthorized(error) ? (
+        <AdminStateMessage
+          title="再ログインしてください。"
+          detail="セッションの有効期限が切れています。ログインし直してください。"
+          signInCallbackUrl={getAdminRuleSetsPath()}
+        />
+      ) : null}
+      {error && isAdminApiForbidden(error) ? (
+        <AdminStateMessage
+          tone="warning"
+          title="RuleSet 管理の権限がありません。"
+          detail="MasterEditor 以上のアカウントでログインしてください。"
+        />
+      ) : null}
+      {error && !isAdminApiUnauthorized(error) && !isAdminApiForbidden(error) ? (
+        <AdminStateMessage tone="error" title="読み込みに失敗しました。" detail={errorMessage ?? undefined} />
+      ) : null}
+
+      {!loading && status === 'authenticated' && !error ? (
+        <AdminSectionCard
+          title="RuleSet 一覧"
+          description="slug、generation、title、version、status、参照状況を確認できます。"
+        >
+          {ruleSets.length === 0 ? (
+            <AdminEmptyState>
+              RuleSet はまだありません。新規作成から追加してください。
+            </AdminEmptyState>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+                <thead>
+                  <tr className="text-left text-zinc-500 dark:text-zinc-400">
+                    <th className="px-3 py-2">Slug</th>
+                    <th className="px-3 py-2">Generation</th>
+                    <th className="px-3 py-2">Title</th>
+                    <th className="px-3 py-2">Version</th>
+                    <th className="px-3 py-2">Status</th>
+                    <th className="px-3 py-2">Referenced</th>
+                    <th className="px-3 py-2">操作</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-100 dark:divide-zinc-900">
+                  {ruleSets.map((ruleSet) => (
+                    <tr key={ruleSet.id}>
+                      <td className="px-3 py-3 font-mono text-xs text-zinc-700 dark:text-zinc-300">{ruleSet.slug}</td>
+                      <td className="px-3 py-3 text-zinc-700 dark:text-zinc-300">{ruleSet.generation}</td>
+                      <td className="px-3 py-3 font-medium text-zinc-900 dark:text-zinc-100">{ruleSet.title}</td>
+                      <td className="px-3 py-3 text-zinc-700 dark:text-zinc-300">{ruleSet.version}</td>
+                      <td className="px-3 py-3 text-zinc-700 dark:text-zinc-300">{ruleSet.status}</td>
+                      <td className="px-3 py-3 text-zinc-700 dark:text-zinc-300">{ruleSet.isReferencedByRuns ? 'Yes' : 'No'}</td>
+                      <td className="px-3 py-3">
+                        <Link className="font-medium text-sky-700 underline underline-offset-2 dark:text-sky-300" href={getAdminRuleSetPath(ruleSet.id)}>
+                          {formatAdminRuleSetLabel(ruleSet)}
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </AdminSectionCard>
+      ) : null}
+    </AdminPageShell>
+  );
+}
+

--- a/components/organisms/PokemonDamageCalculatorAdmin/AdminUserAuthorizationEditorPage.tsx
+++ b/components/organisms/PokemonDamageCalculatorAdmin/AdminUserAuthorizationEditorPage.tsx
@@ -1,0 +1,373 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import CustomButton from '@/components/atoms/CustomButton';
+import {
+  FieldGroup,
+  SelectInput,
+  StatusMessage,
+  TextInput,
+} from '@/components/organisms/PokemonDamageCalculator/shared';
+import { AdminPageShell, AdminStateMessage, AdminSectionCard } from './shared';
+import {
+  createAdminUserAuthorization,
+  deleteAdminUserAuthorization,
+  fetchAdminUserAuthorization,
+  getAdminApiErrorMessage,
+  getAdminProblemDetailsMessage,
+  isAdminApiForbidden,
+  isAdminApiNotFound,
+  isAdminApiUnauthorized,
+  updateAdminUserAuthorization,
+} from '@/lib/pokemon-damage-calculator/admin/api';
+import { canManageUserAuthorizations, probeAdminCapability } from '@/lib/pokemon-damage-calculator/admin/capability';
+import { getAdminUserAuthorizationsPath, getAdminUserAuthorizationPath } from '@/lib/pokemon-damage-calculator/admin/routes';
+import {
+  ADMIN_PERMISSIONS,
+  ADMIN_ROLES,
+  type AdminCapability,
+  type AdminPermission,
+} from '@/lib/pokemon-damage-calculator/admin/constants';
+import type {
+  AdminUserAuthorizationDto,
+  AdminUserAuthorizationFormState,
+  AdminUserAuthorizationUpsertRequest,
+} from '@/lib/pokemon-damage-calculator/admin/types';
+import { toggleAdminPermission, validateAdminUserAuthorizationForm } from '@/lib/pokemon-damage-calculator/admin/validation';
+
+function createEmptyForm(): AdminUserAuthorizationFormState {
+  return {
+    googleUserId: '',
+    role: 'Member',
+    permissions: ['masters.view'],
+  };
+}
+
+function formFromDto(dto: AdminUserAuthorizationDto): AdminUserAuthorizationFormState {
+  return {
+    googleUserId: dto.googleUserId,
+    role: dto.role,
+    permissions: dto.permissions,
+  };
+}
+
+function toRequest(form: AdminUserAuthorizationFormState): AdminUserAuthorizationUpsertRequest {
+  return {
+    googleUserId: form.googleUserId.trim(),
+    role: form.role,
+    permissions: form.permissions,
+  };
+}
+
+export function AdminUserAuthorizationEditorPage({ googleUserId }: { googleUserId?: string }) {
+  const router = useRouter();
+  const { status } = useSession();
+  const isNew = !googleUserId;
+  const [capability, setCapability] = useState<AdminCapability | null>(null);
+  const [capabilityLoading, setCapabilityLoading] = useState(true);
+  const [recordLoading, setRecordLoading] = useState(false);
+  const [recordError, setRecordError] = useState<unknown>(null);
+  const [record, setRecord] = useState<AdminUserAuthorizationDto | null>(null);
+  const [form, setForm] = useState<AdminUserAuthorizationFormState>(createEmptyForm());
+  const [validationErrors, setValidationErrors] = useState<string[]>([]);
+  const [serverMessage, setServerMessage] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadCapability = async () => {
+      if (status === 'loading') {
+        return;
+      }
+
+      try {
+        setCapabilityLoading(true);
+        const nextCapability = await probeAdminCapability(status === 'authenticated');
+        if (!cancelled) {
+          setCapability(nextCapability);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setRecordError(error);
+        }
+      } finally {
+        if (!cancelled) {
+          setCapabilityLoading(false);
+        }
+      }
+    };
+
+    void loadCapability();
+    return () => {
+      cancelled = true;
+    };
+  }, [status]);
+
+  useEffect(() => {
+    if (isNew || !capability || !canManageUserAuthorizations(capability)) {
+      return;
+    }
+
+    if (!googleUserId) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        setRecordLoading(true);
+        setRecordError(null);
+        const nextRecord = await fetchAdminUserAuthorization(googleUserId);
+        if (cancelled) {
+          return;
+        }
+
+        setRecord(nextRecord);
+        setForm(formFromDto(nextRecord));
+      } catch (error) {
+        if (!cancelled) {
+          setRecordError(error);
+        }
+      } finally {
+        if (!cancelled) {
+          setRecordLoading(false);
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [capability, googleUserId, isNew]);
+
+  const pageTitle = isNew ? 'UserAuthorization 新規作成' : 'UserAuthorization 詳細 / 更新';
+
+  const localizedError = useMemo(() => {
+    if (!recordError) {
+      return null;
+    }
+
+    if (isAdminApiUnauthorized(recordError)) {
+      return 'セッションの有効期限が切れています。ログインし直してください。';
+    }
+
+    if (isAdminApiForbidden(recordError)) {
+      return 'UserAuthorization 管理の権限がありません。';
+    }
+
+    if (isAdminApiNotFound(recordError)) {
+      return isNew ? null : getAdminProblemDetailsMessage((recordError as { details?: unknown }).details, '指定した UserAuthorization は見つかりません。');
+    }
+
+    return getAdminApiErrorMessage(recordError, 'UserAuthorization の読み込みに失敗しました。');
+  }, [isNew, recordError]);
+
+  const canEdit = capability ? canManageUserAuthorizations(capability) : false;
+
+  const submit = useCallback(async () => {
+    const errors = validateAdminUserAuthorizationForm(form);
+    setValidationErrors(errors);
+    setServerMessage(null);
+    if (errors.length > 0 || !canEdit) {
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      const request = toRequest(form);
+      const nextRecord = isNew
+        ? await createAdminUserAuthorization(request)
+        : await updateAdminUserAuthorization(googleUserId as string, request);
+      setRecord(nextRecord);
+      setForm(formFromDto(nextRecord));
+      setServerMessage('保存しました。');
+      setDeleteOpen(false);
+      if (isNew) {
+        router.push(getAdminUserAuthorizationPath(nextRecord.googleUserId));
+      }
+    } catch (error) {
+      setServerMessage(getAdminProblemDetailsMessage((error as { details?: unknown }).details, getAdminApiErrorMessage(error, '保存に失敗しました。')));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [canEdit, form, isNew, router, googleUserId]);
+
+  const handleDelete = useCallback(async () => {
+    if (!record || !googleUserId) {
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      setServerMessage(null);
+      await deleteAdminUserAuthorization(googleUserId);
+      router.push(getAdminUserAuthorizationsPath());
+    } catch (error) {
+      setServerMessage(getAdminProblemDetailsMessage((error as { details?: unknown }).details, getAdminApiErrorMessage(error, '削除に失敗しました。')));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [googleUserId, record, router]);
+
+  if (status === 'loading' || capabilityLoading) {
+    return (
+      <AdminPageShell title={pageTitle} description="Google ユーザーの role と permissions を管理します。">
+        <AdminStateMessage title="アクセス権限を確認しています..." />
+      </AdminPageShell>
+    );
+  }
+
+  if (!capability) {
+    if (isAdminApiUnauthorized(recordError)) {
+      return (
+        <AdminPageShell title={pageTitle} description="Google ユーザーの role と permissions を管理します。">
+          <AdminStateMessage
+            title="再ログインしてください。"
+            detail="セッションの有効期限が切れています。ログインし直してください。"
+            signInCallbackUrl={isNew ? getAdminUserAuthorizationsPath() : getAdminUserAuthorizationPath(googleUserId ?? '')}
+          />
+        </AdminPageShell>
+      );
+    }
+
+    return (
+      <AdminPageShell title={pageTitle} description="Google ユーザーの role と permissions を管理します。">
+        <AdminStateMessage
+          tone="error"
+          title="アクセス権限の確認に失敗しました。"
+          detail={localizedError ?? '権限情報を取得できませんでした。'}
+        />
+      </AdminPageShell>
+    );
+  }
+
+  if (status !== 'authenticated') {
+    return (
+      <AdminPageShell title={pageTitle} description="Google ユーザーの role と permissions を管理します。">
+        <AdminStateMessage
+          title="ログインしてください。"
+          detail="UserAuthorization 管理を利用するには Google ログインが必要です。"
+          signInCallbackUrl={isNew ? getAdminUserAuthorizationsPath() : getAdminUserAuthorizationPath(googleUserId ?? '')}
+        />
+      </AdminPageShell>
+    );
+  }
+
+  if (!canEdit) {
+    return (
+      <AdminPageShell title={pageTitle} description="Google ユーザーの role と permissions を管理します。">
+        <AdminStateMessage
+          tone="warning"
+          title="UserAuthorization 管理の権限がありません。"
+          detail="Administrator でログインしてください。"
+        />
+      </AdminPageShell>
+    );
+  }
+
+  if (!isNew && isAdminApiNotFound(recordError)) {
+    return (
+      <AdminPageShell title={pageTitle} description="Google ユーザーの role と permissions を管理します。">
+        <AdminStateMessage
+          tone="warning"
+          title="指定した UserAuthorization は見つかりません。"
+          detail="一覧に戻って別のユーザーを選択してください。"
+          signInCallbackUrl={getAdminUserAuthorizationsPath()}
+        />
+      </AdminPageShell>
+    );
+  }
+
+  return (
+    <AdminPageShell title={pageTitle} description="Google ユーザーの role と permissions を管理します。">
+      <div className="flex flex-wrap gap-3">
+        <CustomButton variant="ghost" onClick={() => router.push(getAdminUserAuthorizationsPath())}>
+          一覧へ戻る
+        </CustomButton>
+        {!isNew ? (
+          <CustomButton variant="ghost" onClick={() => setDeleteOpen((current) => !current)} disabled={submitting}>
+            {deleteOpen ? '削除を閉じる' : '削除'}
+          </CustomButton>
+        ) : null}
+      </div>
+
+      {recordLoading ? <AdminStateMessage title="UserAuthorization を読み込んでいます..." /> : null}
+      {serverMessage ? <AdminStateMessage tone="success" title={serverMessage} /> : null}
+      {localizedError ? <AdminStateMessage tone="error" title="読み込みに失敗しました。" detail={localizedError} /> : null}
+      {validationErrors.length > 0 ? (
+        <StatusMessage tone="error">
+          <ul className="list-disc pl-5">
+            {validationErrors.map((error) => <li key={error}>{error}</li>)}
+          </ul>
+        </StatusMessage>
+      ) : null}
+
+      <AdminSectionCard title="UserAuthorization フォーム" description="backend request DTO と 1 対 1 で対応します。">
+        <div className="grid gap-4 md:grid-cols-2">
+          <FieldGroup label="googleUserId">
+            <TextInput value={form.googleUserId} disabled={submitting || !isNew} onChange={(event) => setForm((current) => ({ ...current, googleUserId: event.target.value }))} />
+          </FieldGroup>
+          <FieldGroup label="role">
+            <SelectInput value={form.role} disabled={submitting} onChange={(event) => setForm((current) => ({ ...current, role: event.target.value as AdminUserAuthorizationFormState['role'] }))}>
+              {ADMIN_ROLES.map((role) => (
+                <option key={role} value={role}>{role}</option>
+              ))}
+            </SelectInput>
+          </FieldGroup>
+        </div>
+
+        <div className="mt-4 space-y-2">
+          <p className="text-sm font-medium text-zinc-800 dark:text-zinc-200">permissions</p>
+          <div className="grid gap-2 md:grid-cols-3">
+            {ADMIN_PERMISSIONS.map((permission) => (
+              <label key={permission} className="flex items-center gap-2 rounded-xl border border-zinc-200 px-3 py-2 text-sm text-zinc-800 dark:border-zinc-800 dark:text-zinc-200">
+                <input
+                  type="checkbox"
+                  checked={form.permissions.includes(permission)}
+                  disabled={submitting}
+                  onChange={() => setForm((current) => ({ ...current, permissions: toggleAdminPermission(current.permissions, permission as AdminPermission) }))}
+                />
+                <span>{permission}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-wrap gap-3">
+          <CustomButton variant="accent" onClick={() => void submit()} disabled={submitting}>
+            {isNew ? '作成' : '更新'}
+          </CustomButton>
+        </div>
+      </AdminSectionCard>
+
+      {!isNew ? (
+        <AdminSectionCard title="削除確認" description="最後の Administrator は backend が 409 Conflict で保護します。">
+          {record?.isLastAdministrator ? (
+            <AdminStateMessage
+              tone="warning"
+              title="このユーザーは最後の Administrator です。"
+              detail="role 変更または削除は 409 Conflict になる可能性があります。"
+            />
+          ) : null}
+          {deleteOpen ? (
+            <div className="flex flex-wrap gap-3">
+              <CustomButton variant="accent" onClick={() => void handleDelete()} disabled={submitting}>
+                削除を実行
+              </CustomButton>
+              <CustomButton variant="ghost" onClick={() => setDeleteOpen(false)} disabled={submitting}>
+                キャンセル
+              </CustomButton>
+            </div>
+          ) : null}
+        </AdminSectionCard>
+      ) : null}
+    </AdminPageShell>
+  );
+}
+

--- a/components/organisms/PokemonDamageCalculatorAdmin/AdminUserAuthorizationListPage.tsx
+++ b/components/organisms/PokemonDamageCalculatorAdmin/AdminUserAuthorizationListPage.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { useCallback, useEffect, useState } from 'react';
+import CustomButton from '@/components/atoms/CustomButton';
+import { AdminPageShell, AdminEmptyState, AdminStateMessage, AdminSectionCard } from './shared';
+import { fetchAdminUserAuthorizations, getAdminApiErrorMessage, isAdminApiForbidden, isAdminApiUnauthorized } from '@/lib/pokemon-damage-calculator/admin/api';
+import { sortAdminUserAuthorizations } from '@/lib/pokemon-damage-calculator/admin/mappers';
+import { getAdminHomePath, getAdminUserAuthorizationNewPath, getAdminUserAuthorizationPath, getAdminUserAuthorizationsPath } from '@/lib/pokemon-damage-calculator/admin/routes';
+import type { AdminUserAuthorizationDto } from '@/lib/pokemon-damage-calculator/admin/types';
+
+export function AdminUserAuthorizationListPage() {
+  const router = useRouter();
+  const { status } = useSession();
+  const [items, setItems] = useState<AdminUserAuthorizationDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<unknown>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const nextItems = await fetchAdminUserAuthorizations();
+      setItems(sortAdminUserAuthorizations(nextItems));
+    } catch (nextError) {
+      setError(nextError);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (status === 'loading') {
+      return;
+    }
+
+    if (status !== 'authenticated') {
+      setLoading(false);
+      return;
+    }
+
+    void load();
+  }, [load, status]);
+
+  const errorMessage = error ? getAdminApiErrorMessage(error, 'UserAuthorization 一覧の読み込みに失敗しました。') : null;
+
+  return (
+    <AdminPageShell
+      title="UserAuthorization 管理"
+      description="Google ユーザーの role と permissions を管理します。"
+    >
+      <div className="flex flex-wrap gap-3">
+        <CustomButton variant="ghost" onClick={() => void load()} disabled={loading || status !== 'authenticated'}>
+          再取得
+        </CustomButton>
+        <CustomButton variant="accent" disabled={status !== 'authenticated'} onClick={() => router.push(getAdminUserAuthorizationNewPath())}>
+          新規作成
+        </CustomButton>
+        <CustomButton variant="ghost" onClick={() => router.push(getAdminHomePath())}>
+          管理トップへ戻る
+        </CustomButton>
+      </div>
+
+      {status === 'loading' || loading ? <AdminStateMessage title="UserAuthorization を読み込んでいます..." /> : null}
+      {status !== 'authenticated' ? (
+        <AdminStateMessage
+          title="ログインしてください。"
+          detail="UserAuthorization 管理を利用するには Google ログインが必要です。"
+          signInCallbackUrl={getAdminUserAuthorizationsPath()}
+        />
+      ) : null}
+      {error && isAdminApiUnauthorized(error) ? (
+        <AdminStateMessage
+          title="再ログインしてください。"
+          detail="セッションの有効期限が切れています。ログインし直してください。"
+          signInCallbackUrl={getAdminUserAuthorizationsPath()}
+        />
+      ) : null}
+      {error && isAdminApiForbidden(error) ? (
+        <AdminStateMessage
+          tone="warning"
+          title="UserAuthorization 管理の権限がありません。"
+          detail="Administrator でログインしてください。"
+        />
+      ) : null}
+      {error && !isAdminApiUnauthorized(error) && !isAdminApiForbidden(error) ? (
+        <AdminStateMessage tone="error" title="読み込みに失敗しました。" detail={errorMessage ?? undefined} />
+      ) : null}
+
+      {!loading && status === 'authenticated' && !error ? (
+        <AdminSectionCard
+          title="UserAuthorization 一覧"
+          description="googleUserId、role、permissions、最終管理者保護を確認できます。"
+        >
+          {items.length === 0 ? (
+            <AdminEmptyState>
+              UserAuthorization はまだありません。新規作成から追加してください。
+            </AdminEmptyState>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
+                <thead>
+                  <tr className="text-left text-zinc-500 dark:text-zinc-400">
+                    <th className="px-3 py-2">Google User ID</th>
+                    <th className="px-3 py-2">Role</th>
+                    <th className="px-3 py-2">Permissions</th>
+                    <th className="px-3 py-2">Last Admin</th>
+                    <th className="px-3 py-2">操作</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-100 dark:divide-zinc-900">
+                  {items.map((item) => (
+                    <tr key={item.googleUserId}>
+                      <td className="px-3 py-3 font-mono text-xs text-zinc-700 dark:text-zinc-300">{item.googleUserId}</td>
+                      <td className="px-3 py-3 text-zinc-700 dark:text-zinc-300">{item.role}</td>
+                      <td className="px-3 py-3 text-zinc-700 dark:text-zinc-300">{item.permissions.join(', ') || '—'}</td>
+                      <td className="px-3 py-3 text-zinc-700 dark:text-zinc-300">{item.isLastAdministrator ? 'Yes' : 'No'}</td>
+                      <td className="px-3 py-3">
+                        <Link className="font-medium text-sky-700 underline underline-offset-2 dark:text-sky-300" href={getAdminUserAuthorizationPath(item.googleUserId)}>
+                          詳細を開く
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </AdminSectionCard>
+      ) : null}
+    </AdminPageShell>
+  );
+}
+

--- a/components/organisms/PokemonDamageCalculatorAdmin/shared.tsx
+++ b/components/organisms/PokemonDamageCalculatorAdmin/shared.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import Link from 'next/link';
+import { signIn, useSession } from 'next-auth/react';
+import type { ReactNode } from 'react';
+import CustomButton from '@/components/atoms/CustomButton';
+import {
+  EmptyState,
+  PageShell,
+  SectionCard,
+  StatusMessage,
+} from '@/components/organisms/PokemonDamageCalculator/shared';
+import {
+  getAdminHomePath,
+  getAdminRuleSetsPath,
+  getAdminUserAuthorizationsPath,
+} from '@/lib/pokemon-damage-calculator/admin/routes';
+
+export function AdminPageShell({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <PageShell title={title} description={description}>
+      <div className="flex flex-wrap gap-3">
+        <Link className="text-sm font-medium text-sky-700 underline underline-offset-2 dark:text-sky-300" href={getAdminHomePath()}>
+          管理トップ
+        </Link>
+        <Link className="text-sm font-medium text-sky-700 underline underline-offset-2 dark:text-sky-300" href={getAdminRuleSetsPath()}>
+          RuleSet 管理
+        </Link>
+        <Link className="text-sm font-medium text-sky-700 underline underline-offset-2 dark:text-sky-300" href={getAdminUserAuthorizationsPath()}>
+          UserAuthorization 管理
+        </Link>
+      </div>
+      {children}
+    </PageShell>
+  );
+}
+
+export function AdminStateMessage({
+  title,
+  detail,
+  tone = 'info',
+  signInCallbackUrl,
+}: {
+  title: string;
+  detail?: string;
+  tone?: 'info' | 'warning' | 'error' | 'success';
+  signInCallbackUrl?: string;
+}) {
+  const { status } = useSession();
+
+  return (
+    <StatusMessage tone={tone}>
+      <div className="space-y-3">
+        <p className="font-medium">{title}</p>
+        {detail ? <p>{detail}</p> : null}
+        {status !== 'authenticated' && signInCallbackUrl ? (
+          <CustomButton variant="accent" onClick={() => void signIn('google', { callbackUrl: signInCallbackUrl })}>
+            Google でログイン
+          </CustomButton>
+        ) : null}
+      </div>
+    </StatusMessage>
+  );
+}
+
+export function AdminEmptyState({ children }: { children: ReactNode }) {
+  return <EmptyState>{children}</EmptyState>;
+}
+
+export function AdminSectionCard(props: Parameters<typeof SectionCard>[0]) {
+  return <SectionCard {...props} />;
+}
+

--- a/docs/API_CONTRACT_DIFFS_POKEMON_DAMAGE_CALCULATOR_API.md
+++ b/docs/API_CONTRACT_DIFFS_POKEMON_DAMAGE_CALCULATOR_API.md
@@ -8,6 +8,7 @@
 |------|----------|
 | feature entry | `/pokemon-damage-calculator` |
 | Run workspace | `/pokemon-damage-calculator/runs/[runId]` |
+| admin entry | `/pokemon-damage-calculator/admin` |
 | 利用 API | `pokemon-damage-calculator-api` |
 | API 呼び出し方式 | `createFrontendApiClient` + `/api/services/{service}/{...path}` proxy |
 | 認証伝搬 | `Authorization` と `X-Google-Access-Token` を維持 |
@@ -26,6 +27,9 @@
 |------|------|------|
 | `/pokemon-damage-calculator` | feature entry | RuleSet 一覧、Run 一覧、Run 作成 |
 | `/pokemon-damage-calculator/runs/[runId]` | Run workspace | Run 詳細、Battle 管理、Party State、ダメージ計算 |
+| `/pokemon-damage-calculator/admin` | admin entry | RuleSet / UserAuthorization 管理ハブ |
+| `/pokemon-damage-calculator/admin/rule-sets` | admin RuleSet | 一覧 / 作成 / 詳細 / 更新 / 削除 |
+| `/pokemon-damage-calculator/admin/user-authorizations` | admin UserAuthorization | 一覧 / 作成 / 詳細 / 更新 / 削除 |
 
 ## API 利用方針
 
@@ -105,6 +109,14 @@
 - workspace では Run / Battle / Party State を再取得し、更新後に一覧とフォーム状態を同期する
 - Party State は append-only とし、既存スナップショットは表示のみ提供する
 - ダメージ計算結果は最新 1 件を画面内に保持し、Damage Rolls と送信パラメータを表示する
+
+## Admin master maintenance
+
+- 管理 UI は `game-management` とは独立した feature-local route として `/pokemon-damage-calculator/admin` 配下に追加した
+- 管理 API は `pokemon-damage-calculator-api` の `/api/admin/*` をそのまま利用し、public UI とは API 契約を分離した
+- role 判定 API はないため、admin top と new/edit 画面では GET 成否から capability probing を行う
+- `ProblemDetails` は `status/title/detail` ベースで扱い、送信前の local validation は frontend 側の `string[]` メッセージで表示する
+- 404 / 409 の deep link / conflict は一覧へ戻る導線と入力保持を優先する
 
 ## 関連ドキュメント
 

--- a/lib/pokemon-damage-calculator/admin/api.ts
+++ b/lib/pokemon-damage-calculator/admin/api.ts
@@ -1,0 +1,135 @@
+import { createFrontendApiClient } from '@/lib/api/frontend-client';
+import type { ApiResponse } from '@/lib/types/api';
+import { POKEMON_DAMAGE_CALCULATOR_SERVICE_NAME } from '../constants';
+import type {
+  AdminRuleSetDto,
+  AdminRuleSetUpsertRequest,
+  AdminUserAuthorizationDto,
+  AdminUserAuthorizationUpsertRequest,
+  ProblemDetails,
+} from './types';
+
+const client = createFrontendApiClient(POKEMON_DAMAGE_CALCULATOR_SERVICE_NAME);
+
+export class AdminApiError extends Error {
+  public readonly code: string;
+  public readonly statusCode: number | null;
+  public readonly details?: unknown;
+
+  constructor(message: string, code: string, statusCode: number | null, details?: unknown) {
+    super(message);
+    this.name = 'AdminApiError';
+    this.code = code;
+    this.statusCode = statusCode;
+    this.details = details;
+  }
+}
+
+function getStatusCode(code: string): number | null {
+  return code.startsWith('HTTP_') ? Number.parseInt(code.slice(5), 10) : null;
+}
+
+function isProblemDetails(value: unknown): value is ProblemDetails {
+  return Boolean(value) && typeof value === 'object';
+}
+
+function formatProblemDetails(details: unknown, fallback: string): string {
+  if (!isProblemDetails(details)) {
+    return fallback;
+  }
+
+  return [details.title, details.detail].filter((value): value is string => Boolean(value)).join('\n') || fallback;
+}
+
+async function unwrap<T>(promise: Promise<ApiResponse<T>>): Promise<T> {
+  const response = await promise;
+
+  if (response.success) {
+    return response.data;
+  }
+
+  throw new AdminApiError(
+    response.error.message,
+    response.error.code,
+    getStatusCode(response.error.code),
+    response.error.details,
+  );
+}
+
+export function getAdminApiErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof AdminApiError) {
+    return formatProblemDetails(error.details, error.message || fallback);
+  }
+
+  return error instanceof Error ? error.message : fallback;
+}
+
+export function getAdminProblemDetailsMessage(details: unknown, fallback: string): string {
+  return formatProblemDetails(details, fallback);
+}
+
+export function isAdminApiStatusError(error: unknown, statusCode: number): boolean {
+  return error instanceof AdminApiError && error.statusCode === statusCode;
+}
+
+export function isAdminApiForbidden(error: unknown): boolean {
+  return isAdminApiStatusError(error, 403);
+}
+
+export function isAdminApiUnauthorized(error: unknown): boolean {
+  return isAdminApiStatusError(error, 401);
+}
+
+export function isAdminApiNotFound(error: unknown): boolean {
+  return isAdminApiStatusError(error, 404);
+}
+
+export function isAdminApiConflict(error: unknown): boolean {
+  return isAdminApiStatusError(error, 409);
+}
+
+export async function fetchAdminRuleSets(): Promise<AdminRuleSetDto[]> {
+  return unwrap(client.get<AdminRuleSetDto[]>('/api/admin/rule-sets'));
+}
+
+export async function fetchAdminRuleSet(id: string): Promise<AdminRuleSetDto> {
+  return unwrap(client.get<AdminRuleSetDto>(`/api/admin/rule-sets/${id}`));
+}
+
+export async function createAdminRuleSet(request: AdminRuleSetUpsertRequest): Promise<AdminRuleSetDto> {
+  return unwrap(client.post<AdminRuleSetDto>('/api/admin/rule-sets', request));
+}
+
+export async function updateAdminRuleSet(id: string, request: AdminRuleSetUpsertRequest): Promise<AdminRuleSetDto> {
+  return unwrap(client.put<AdminRuleSetDto>(`/api/admin/rule-sets/${id}`, request));
+}
+
+export async function deleteAdminRuleSet(id: string): Promise<void> {
+  await unwrap(client.delete<void>(`/api/admin/rule-sets/${id}`));
+}
+
+export async function fetchAdminUserAuthorizations(): Promise<AdminUserAuthorizationDto[]> {
+  return unwrap(client.get<AdminUserAuthorizationDto[]>('/api/admin/user-authorizations'));
+}
+
+export async function fetchAdminUserAuthorization(googleUserId: string): Promise<AdminUserAuthorizationDto> {
+  return unwrap(client.get<AdminUserAuthorizationDto>(`/api/admin/user-authorizations/${encodeURIComponent(googleUserId)}`));
+}
+
+export async function createAdminUserAuthorization(
+  request: AdminUserAuthorizationUpsertRequest,
+): Promise<AdminUserAuthorizationDto> {
+  return unwrap(client.post<AdminUserAuthorizationDto>('/api/admin/user-authorizations', request));
+}
+
+export async function updateAdminUserAuthorization(
+  googleUserId: string,
+  request: AdminUserAuthorizationUpsertRequest,
+): Promise<AdminUserAuthorizationDto> {
+  return unwrap(client.put<AdminUserAuthorizationDto>(`/api/admin/user-authorizations/${encodeURIComponent(googleUserId)}`, request));
+}
+
+export async function deleteAdminUserAuthorization(googleUserId: string): Promise<void> {
+  await unwrap(client.delete<void>(`/api/admin/user-authorizations/${encodeURIComponent(googleUserId)}`));
+}
+

--- a/lib/pokemon-damage-calculator/admin/capability.test.ts
+++ b/lib/pokemon-damage-calculator/admin/capability.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { canManageRuleSets, canManageUserAuthorizations, probeAdminCapability } from './capability';
+import * as mockedApi from './api';
+
+vi.mock('./api', () => ({
+  fetchAdminRuleSets: vi.fn(),
+  fetchAdminUserAuthorizations: vi.fn(),
+  isAdminApiForbidden: (error: { statusCode?: number }) => error.statusCode === 403,
+  isAdminApiUnauthorized: (error: { statusCode?: number }) => error.statusCode === 401,
+}));
+
+describe('admin capability', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('detects anonymous without session', async () => {
+    expect(await probeAdminCapability(false)).toBe('anonymous');
+  });
+
+  it('detects member from forbidden rule set access', async () => {
+    vi.mocked(mockedApi.fetchAdminRuleSets).mockRejectedValueOnce({ statusCode: 403 });
+
+    expect(await probeAdminCapability(true)).toBe('member');
+  });
+
+  it('detects administrator when both calls succeed', async () => {
+    vi.mocked(mockedApi.fetchAdminRuleSets).mockResolvedValueOnce([]);
+    vi.mocked(mockedApi.fetchAdminUserAuthorizations).mockResolvedValueOnce([]);
+
+    expect(await probeAdminCapability(true)).toBe('administrator');
+  });
+
+  it('maps capability checks', () => {
+    expect(canManageRuleSets('member')).toBe(false);
+    expect(canManageRuleSets('masterEditor')).toBe(true);
+    expect(canManageUserAuthorizations('masterEditor')).toBe(false);
+    expect(canManageUserAuthorizations('administrator')).toBe(true);
+  });
+});
+

--- a/lib/pokemon-damage-calculator/admin/capability.ts
+++ b/lib/pokemon-damage-calculator/admin/capability.ts
@@ -1,0 +1,36 @@
+import { isAdminApiForbidden, fetchAdminRuleSets, fetchAdminUserAuthorizations } from './api';
+import type { AdminCapability } from './constants';
+
+export async function probeAdminCapability(isAuthenticated: boolean): Promise<AdminCapability> {
+  if (!isAuthenticated) {
+    return 'anonymous';
+  }
+
+  try {
+    await fetchAdminRuleSets();
+  } catch (error) {
+    if (isAdminApiForbidden(error)) {
+      return 'member';
+    }
+    throw error;
+  }
+
+  try {
+    await fetchAdminUserAuthorizations();
+    return 'administrator';
+  } catch (error) {
+    if (isAdminApiForbidden(error)) {
+      return 'masterEditor';
+    }
+    throw error;
+  }
+}
+
+export function canManageRuleSets(capability: AdminCapability): boolean {
+  return capability === 'masterEditor' || capability === 'administrator';
+}
+
+export function canManageUserAuthorizations(capability: AdminCapability): boolean {
+  return capability === 'administrator';
+}
+

--- a/lib/pokemon-damage-calculator/admin/constants.ts
+++ b/lib/pokemon-damage-calculator/admin/constants.ts
@@ -1,0 +1,18 @@
+export const POKEMON_DAMAGE_CALCULATOR_ADMIN_BASE_PATH = '/pokemon-damage-calculator/admin' as const;
+
+export const ADMIN_RULE_SET_STATUSES = ['Active', 'Draft', 'Archived'] as const;
+export type AdminRuleSetStatus = (typeof ADMIN_RULE_SET_STATUSES)[number];
+
+export const ADMIN_ROLES = ['Administrator', 'MasterEditor', 'Member'] as const;
+export type AdminRole = (typeof ADMIN_ROLES)[number];
+
+export const ADMIN_PERMISSIONS = [
+  'masters.view',
+  'masters.rulesets.manage',
+  'masters.user-authorizations.manage',
+] as const;
+export type AdminPermission = (typeof ADMIN_PERMISSIONS)[number];
+
+export const ADMIN_CAPABILITIES = ['anonymous', 'member', 'masterEditor', 'administrator'] as const;
+export type AdminCapability = (typeof ADMIN_CAPABILITIES)[number];
+

--- a/lib/pokemon-damage-calculator/admin/mappers.ts
+++ b/lib/pokemon-damage-calculator/admin/mappers.ts
@@ -1,0 +1,18 @@
+import type { AdminRuleSetDto, AdminUserAuthorizationDto } from './types';
+
+export function sortAdminRuleSets(ruleSets: AdminRuleSetDto[]): AdminRuleSetDto[] {
+  return [...ruleSets].sort((left, right) => (
+    left.generation - right.generation
+    || left.slug.localeCompare(right.slug, 'ja')
+    || left.title.localeCompare(right.title, 'ja')
+  ));
+}
+
+export function sortAdminUserAuthorizations(items: AdminUserAuthorizationDto[]): AdminUserAuthorizationDto[] {
+  return [...items].sort((left, right) => left.googleUserId.localeCompare(right.googleUserId, 'ja'));
+}
+
+export function formatAdminRuleSetLabel(ruleSet: AdminRuleSetDto): string {
+  return `${ruleSet.title} / ${ruleSet.slug} (${ruleSet.version})`;
+}
+

--- a/lib/pokemon-damage-calculator/admin/routes.test.ts
+++ b/lib/pokemon-damage-calculator/admin/routes.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getAdminRuleSetPath,
+  getAdminUserAuthorizationPath,
+} from './routes';
+
+describe('admin routes', () => {
+  it('encodes route params', () => {
+    expect(getAdminRuleSetPath('rule/1')).toBe('/pokemon-damage-calculator/admin/rule-sets/rule%2F1');
+    expect(getAdminUserAuthorizationPath('user@example.com')).toBe('/pokemon-damage-calculator/admin/user-authorizations/user%40example.com');
+  });
+});
+

--- a/lib/pokemon-damage-calculator/admin/routes.ts
+++ b/lib/pokemon-damage-calculator/admin/routes.ts
@@ -1,0 +1,30 @@
+import { POKEMON_DAMAGE_CALCULATOR_ADMIN_BASE_PATH } from './constants';
+
+export function getAdminHomePath(): string {
+  return POKEMON_DAMAGE_CALCULATOR_ADMIN_BASE_PATH;
+}
+
+export function getAdminRuleSetsPath(): string {
+  return `${POKEMON_DAMAGE_CALCULATOR_ADMIN_BASE_PATH}/rule-sets`;
+}
+
+export function getAdminRuleSetNewPath(): string {
+  return `${getAdminRuleSetsPath()}/new`;
+}
+
+export function getAdminRuleSetPath(id: string): string {
+  return `${getAdminRuleSetsPath()}/${encodeURIComponent(id)}`;
+}
+
+export function getAdminUserAuthorizationsPath(): string {
+  return `${POKEMON_DAMAGE_CALCULATOR_ADMIN_BASE_PATH}/user-authorizations`;
+}
+
+export function getAdminUserAuthorizationNewPath(): string {
+  return `${getAdminUserAuthorizationsPath()}/new`;
+}
+
+export function getAdminUserAuthorizationPath(googleUserId: string): string {
+  return `${getAdminUserAuthorizationsPath()}/${encodeURIComponent(googleUserId)}`;
+}
+

--- a/lib/pokemon-damage-calculator/admin/types.ts
+++ b/lib/pokemon-damage-calculator/admin/types.ts
@@ -1,0 +1,73 @@
+import {
+  ADMIN_PERMISSIONS,
+  ADMIN_ROLES,
+  ADMIN_RULE_SET_STATUSES,
+} from './constants';
+import type {
+  AdminPermission,
+  AdminRole,
+  AdminRuleSetStatus,
+} from './constants';
+
+export type ProblemDetails = {
+  type?: string;
+  title?: string;
+  status?: number;
+  detail?: string;
+  instance?: string;
+};
+
+export type AdminRuleSetDto = {
+  id: string;
+  slug: string;
+  generation: number;
+  title: string;
+  version: string;
+  status: AdminRuleSetStatus;
+  summary: string;
+  isReferencedByRuns: boolean;
+};
+
+export type AdminUserAuthorizationDto = {
+  googleUserId: string;
+  role: AdminRole;
+  permissions: AdminPermission[];
+  isLastAdministrator: boolean;
+};
+
+export type AdminRuleSetUpsertRequest = {
+  slug: string;
+  generation: number;
+  title: string;
+  version: string;
+  status: AdminRuleSetStatus;
+  summary: string;
+};
+
+export type AdminUserAuthorizationUpsertRequest = {
+  googleUserId: string;
+  role: AdminRole;
+  permissions: AdminPermission[];
+};
+
+export type AdminRuleSetFormState = {
+  slug: string;
+  generation: string;
+  title: string;
+  version: string;
+  status: AdminRuleSetStatus;
+  summary: string;
+};
+
+export type AdminUserAuthorizationFormState = {
+  googleUserId: string;
+  role: AdminRole;
+  permissions: AdminPermission[];
+};
+
+export type AdminCatalog = {
+  roles: typeof ADMIN_ROLES;
+  permissions: typeof ADMIN_PERMISSIONS;
+  ruleSetStatuses: typeof ADMIN_RULE_SET_STATUSES;
+};
+

--- a/lib/pokemon-damage-calculator/admin/validation.test.ts
+++ b/lib/pokemon-damage-calculator/admin/validation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { toggleAdminPermission, validateAdminRuleSetForm, validateAdminUserAuthorizationForm } from './validation';
+
+describe('admin validation', () => {
+  it('validates rule set forms', () => {
+    expect(validateAdminRuleSetForm({
+      slug: '',
+      generation: '0',
+      title: '',
+      version: '',
+      status: 'Invalid' as never,
+      summary: '',
+    })).toEqual([
+      'RuleSet の slug を入力してください。',
+      'generation は 1 以上の整数で入力してください。',
+      'RuleSet の title を入力してください。',
+      'version を入力してください。',
+      'status を選択してください。',
+      'summary を入力してください。',
+    ]);
+  });
+
+  it('validates user authorization forms', () => {
+    expect(validateAdminUserAuthorizationForm({
+      googleUserId: '',
+      role: 'Invalid' as never,
+      permissions: ['masters.view', 'masters.view', 'invalid.permission' as never],
+    })).toEqual([
+      'googleUserId を入力してください。',
+      'role を選択してください。',
+      'permissions に重複があります。',
+      'permissions に許可されていない値が含まれています。',
+    ]);
+  });
+
+  it('toggles permissions without duplicates', () => {
+    expect(toggleAdminPermission(['masters.view'], 'masters.rulesets.manage')).toEqual(['masters.view', 'masters.rulesets.manage']);
+    expect(toggleAdminPermission(['masters.view', 'masters.rulesets.manage'], 'masters.view')).toEqual(['masters.rulesets.manage']);
+  });
+});
+

--- a/lib/pokemon-damage-calculator/admin/validation.ts
+++ b/lib/pokemon-damage-calculator/admin/validation.ts
@@ -1,0 +1,50 @@
+import { ADMIN_PERMISSIONS, ADMIN_ROLES, ADMIN_RULE_SET_STATUSES } from './constants';
+import type { AdminPermission } from './constants';
+import type { AdminRuleSetFormState, AdminUserAuthorizationFormState } from './types';
+
+function isPositiveInteger(text: string): boolean {
+  return /^([1-9]\d*)$/.test(text);
+}
+
+function uniqueValues<T>(values: T[]): T[] {
+  return Array.from(new Set(values));
+}
+
+export function validateAdminRuleSetForm(form: AdminRuleSetFormState): string[] {
+  const errors: string[] = [];
+
+  if (!form.slug.trim()) errors.push('RuleSet の slug を入力してください。');
+  if (!isPositiveInteger(form.generation.trim())) errors.push('generation は 1 以上の整数で入力してください。');
+  if (!form.title.trim()) errors.push('RuleSet の title を入力してください。');
+  if (!form.version.trim()) errors.push('version を入力してください。');
+  if (!ADMIN_RULE_SET_STATUSES.includes(form.status)) errors.push('status を選択してください。');
+  if (!form.summary.trim()) errors.push('summary を入力してください。');
+
+  return errors;
+}
+
+export function validateAdminUserAuthorizationForm(form: AdminUserAuthorizationFormState): string[] {
+  const errors: string[] = [];
+
+  if (!form.googleUserId.trim()) errors.push('googleUserId を入力してください。');
+  if (!ADMIN_ROLES.includes(form.role)) errors.push('role を選択してください。');
+
+  const uniquePermissions = uniqueValues(form.permissions);
+  if (uniquePermissions.length !== form.permissions.length) {
+    errors.push('permissions に重複があります。');
+  }
+
+  const invalidPermissions = form.permissions.filter((permission) => !ADMIN_PERMISSIONS.includes(permission));
+  if (invalidPermissions.length > 0) {
+    errors.push('permissions に許可されていない値が含まれています。');
+  }
+
+  return errors;
+}
+
+export function toggleAdminPermission(current: AdminPermission[], permission: AdminPermission): AdminPermission[] {
+  return current.includes(permission)
+    ? current.filter((value) => value !== permission)
+    : [...current, permission];
+}
+


### PR DESCRIPTION
﻿﻿## 概要 ポケモンダメージ計算 feature に、backend の管理 API を利用するマスタメンテナンス UI を追加します。  ## 変更内容 - `/pokemon-damage-calculator/admin` 配下の管理トップ、RuleSet 管理、UserAuthorization 管理を追加 - admin 専用 API client / capability probing / validation / route helper を追加 - `ProblemDetails(status/title/detail)` と local validation (`string[]`) を分離 - docs / README を更新 - admin 用 unit test と E2E smoke を追加  ## 関連 Issue Closes #99 Depends on #98  ## 確認事項 - [x] `npm run lint` - [x] `npm run build` - [x] `npx vitest run --project unit` - [x] admin 未ログイン E2E smoke  <!-- lifecycle-state
feature: "ポケモンダメージ計算マスタメンテナンス画面"
entry_mode: "new"
issue: 99
pr: 100
branch: "feature/99-pokemon-damage-calculator-admin"
plan_comment_url: "https://github.com/p-o-ke-nae/pokenae.Web/issues/99#issuecomment-4524104398"
phase: 3
step: "3.11"
status: "WAITING_HUMAN"
last_agent: "Architect"
last_decision: "COMPLETE"
counters:
  spec_review: 3
  design_review: 0
  build_fail: 0
  code_review: 1
  completion_cycle: 1
  e2e_retry: 1
  doc_update: 1
updated_at: "2026-05-23T04:25:00Z"
-->